### PR TITLE
[고정민] - (3-3) 관찰자(Observer) 패턴

### DIFF
--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		5F35E2052A67BA86001ECDB8 /* SlideListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F35E2042A67BA86001ECDB8 /* SlideListView.swift */; };
 		5F35E2072A67BD75001ECDB8 /* Selectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F35E2062A67BD75001ECDB8 /* Selectable.swift */; };
 		5F35E2092A67C80D001ECDB8 /* KeynoteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F35E2082A67C80D001ECDB8 /* KeynoteView.swift */; };
+		5F369E652A70B81F00AEDDE4 /* SlideRGBColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F369E642A70B81F00AEDDE4 /* SlideRGBColor+.swift */; };
 		5F3A60D32A6687FD0012212B /* SlideContentManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A60D22A6687FD0012212B /* SlideContentManageable.swift */; };
 		5F3A60D52A6688190012212B /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A60D42A6688190012212B /* Order.swift */; };
 		5F3A60D82A6688450012212B /* SlideRGBColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A60D72A6688450012212B /* SlideRGBColor.swift */; };
@@ -23,6 +24,7 @@
 		5F3A60DC2A6688A30012212B /* BaseSlide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A60DB2A6688A30012212B /* BaseSlide.swift */; };
 		5F3A60DE2A668A100012212B /* AlphaLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A60DD2A668A100012212B /* AlphaLevel.swift */; };
 		5F3A60E02A6695E20012212B /* IDGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A60DF2A6695E20012212B /* IDGenerator.swift */; };
+		5F448CF72A709AD100239DBA /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F448CF62A709AD100239DBA /* NotificationName.swift */; };
 		5F4DC8912A68B8C500DC3CF6 /* BaseElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DC8902A68B8C500DC3CF6 /* BaseElement.swift */; };
 		5F4DC8932A68B9D000DC3CF6 /* RectangleComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DC8922A68B9D000DC3CF6 /* RectangleComponentView.swift */; };
 		5F4DC8962A68BAA600DC3CF6 /* ComponentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DC8952A68BAA600DC3CF6 /* ComponentFactory.swift */; };
@@ -75,6 +77,7 @@
 		5F35E2042A67BA86001ECDB8 /* SlideListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideListView.swift; sourceTree = "<group>"; };
 		5F35E2062A67BD75001ECDB8 /* Selectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selectable.swift; sourceTree = "<group>"; };
 		5F35E2082A67C80D001ECDB8 /* KeynoteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeynoteView.swift; sourceTree = "<group>"; };
+		5F369E642A70B81F00AEDDE4 /* SlideRGBColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SlideRGBColor+.swift"; sourceTree = "<group>"; };
 		5F3A60D22A6687FD0012212B /* SlideContentManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideContentManageable.swift; sourceTree = "<group>"; };
 		5F3A60D42A6688190012212B /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		5F3A60D72A6688450012212B /* SlideRGBColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideRGBColor.swift; sourceTree = "<group>"; };
@@ -82,6 +85,7 @@
 		5F3A60DB2A6688A30012212B /* BaseSlide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseSlide.swift; sourceTree = "<group>"; };
 		5F3A60DD2A668A100012212B /* AlphaLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlphaLevel.swift; sourceTree = "<group>"; };
 		5F3A60DF2A6695E20012212B /* IDGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDGenerator.swift; sourceTree = "<group>"; };
+		5F448CF62A709AD100239DBA /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		5F4DC8902A68B8C500DC3CF6 /* BaseElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseElement.swift; sourceTree = "<group>"; };
 		5F4DC8922A68B9D000DC3CF6 /* RectangleComponentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleComponentView.swift; sourceTree = "<group>"; };
 		5F4DC8952A68BAA600DC3CF6 /* ComponentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentFactory.swift; sourceTree = "<group>"; };
@@ -146,6 +150,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		5F448CF52A709ABE00239DBA /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+				5F448CF62A709AD100239DBA /* NotificationName.swift */,
+			);
+			path = Notification;
+			sourceTree = "<group>";
+		};
 		5F4DC8942A68BA9100DC3CF6 /* Factory */ = {
 			isa = PBXGroup;
 			children = (
@@ -189,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				5F593B8A2A69780F0069C24F /* UIColor.swift */,
+				5F369E642A70B81F00AEDDE4 /* SlideRGBColor+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -262,6 +275,7 @@
 		5FBA89E82A64FFC900C07196 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				5F448CF52A709ABE00239DBA /* Notification */,
 				5F4DC89D2A68D29400DC3CF6 /* Manager */,
 				5F4DC89A2A68C42900DC3CF6 /* Element */,
 				5F4DC8972A68C3C600DC3CF6 /* Slide */,
@@ -445,6 +459,7 @@
 				5F3A60D32A6687FD0012212B /* SlideContentManageable.swift in Sources */,
 				5F35E1FE2A67B939001ECDB8 /* SlideManager.swift in Sources */,
 				5F35E2072A67BD75001ECDB8 /* Selectable.swift in Sources */,
+				5F448CF72A709AD100239DBA /* NotificationName.swift in Sources */,
 				5F35E2032A67BA5D001ECDB8 /* InspectorView.swift in Sources */,
 				5F3A60D52A6688190012212B /* Order.swift in Sources */,
 				5F35E2002A67B95B001ECDB8 /* SlideCollection.swift in Sources */,
@@ -453,6 +468,7 @@
 				5F4DC8912A68B8C500DC3CF6 /* BaseElement.swift in Sources */,
 				5F4DC8932A68B9D000DC3CF6 /* RectangleComponentView.swift in Sources */,
 				5F3A60DC2A6688A30012212B /* BaseSlide.swift in Sources */,
+				5F369E652A70B81F00AEDDE4 /* SlideRGBColor+.swift in Sources */,
 				5F593B8B2A69780F0069C24F /* UIColor.swift in Sources */,
 				5F3A60DA2A66887C0012212B /* AnimationApplicable.swift in Sources */,
 				5FBA89B92A64FFC300C07196 /* AppDelegate.swift in Sources */,

--- a/MyKeynote/MyKeynote/Component/BaseComponentView.swift
+++ b/MyKeynote/MyKeynote/Component/BaseComponentView.swift
@@ -8,23 +8,16 @@
 import Foundation
 import UIKit
 class BaseComponentView: UIView {
-    private var element: SlideElementProtocol?{
-        didSet {
-            updateBorder()
+    
+    var id : String = ""
+    var isSelected: Bool? {
+            didSet {
+                updateBorder()
+            }
         }
-    }
-
-    
-    var color: UIColor {
-        return self.backgroundColor ?? .clear
-    }
-    
-    var alphaValue: Float {
-        return element?.alpha.rawValue ?? 1.0
-    }
     
     func configure(with rectangleElement: SlideElementProtocol) {
-        self.element = rectangleElement
+        id = rectangleElement.id
         self.frame.size = rectangleElement.size
         let rgbColor = rectangleElement.backgroundColor
   
@@ -32,18 +25,12 @@ class BaseComponentView: UIView {
         updateBorder()
     }
     
-    func select() {
-        element?.select()
-        updateBorder()
-    }
-   
-    func deselect() {
-        element?.deselect()
-        updateBorder()
-    }
+    func updateSelectedState(isSelected: Bool) {
+            self.isSelected = isSelected
+        }
 
     private func updateBorder() {
-        layer.borderWidth = element?.isSelected == true ? 4.0 : 0.0
+        layer.borderWidth = self.isSelected == true ? 4.0 : 0.0
         layer.borderColor = UIColor.blue.cgColor
     }
 }

--- a/MyKeynote/MyKeynote/DI/CompositionRoot.swift
+++ b/MyKeynote/MyKeynote/DI/CompositionRoot.swift
@@ -6,29 +6,26 @@
 //
 
 import Foundation
-enum CompositionRoot{
-    static var rootViewController : KeynoteViewController{
-        KeynoteViewController(slideManager: slideManager)
+class CompositionRoot {
+    static let shared = CompositionRoot()
+    
+    let rootViewController: KeynoteViewController
+    let slideManager: SlideManager
+    let componentFactory: SlideComponentFactoryProtocol
+    let slideFactory: SlideFactoryProtocol
+    let slideCollection: SlideCollection
+    
+    private init() {
+        componentFactory = SlideComponentFactory()
+        slideFactory = SlideFactory()
+        slideCollection = SlideCollection()
+        slideManager = SlideManager(componentFactory: componentFactory,
+                                    slideFactory: slideFactory,
+                                    slideCollection: slideCollection)
+        rootViewController = KeynoteViewController(slideManager: slideManager)
     }
-    
-    private static var slideManager : SlideManager{
-        SlideManager(componentFactory: componentFactory, slideFactory: slideFactory , slideCollection: slideCollection)
-    }
-    
-    private static var componentFactory : SlideComponentFactoryProtocol{
-        SlideComponentFactory()
-    }
-    
-    private static var slideFactory : SlideFactoryProtocol{
-        SlideFactory()
-    }
-    
-    private static var slideCollection : SlideCollection{
-        SlideCollection()
-    }
-    
-    
-    
-    
-    
 }
+
+
+
+

--- a/MyKeynote/MyKeynote/Extension/SlideRGBColor+.swift
+++ b/MyKeynote/MyKeynote/Extension/SlideRGBColor+.swift
@@ -1,0 +1,8 @@
+//
+//  SlideRGBColor+.swift
+//  MyKeynote
+//
+//  Created by KoJeongMin  on 2023/07/26.
+//
+
+import Foundation

--- a/MyKeynote/MyKeynote/Extension/SlideRGBColor+.swift
+++ b/MyKeynote/MyKeynote/Extension/SlideRGBColor+.swift
@@ -6,3 +6,15 @@
 //
 
 import Foundation
+import UIKit
+extension SlideRGBColor {
+    init?(color: UIColor) {
+        guard let components = color.cgColor.components, components.count >= 3 else {
+            return nil
+        }
+        
+        self.red = Int(components[0] * 255.0)
+        self.green = Int(components[1] * 255.0)
+        self.blue = Int(components[2] * 255.0)
+    }
+}

--- a/MyKeynote/MyKeynote/Extension/UIColor.swift
+++ b/MyKeynote/MyKeynote/Extension/UIColor.swift
@@ -24,4 +24,15 @@ extension UIColor {
             let b = Float(components[2])
             return String(format: "0x%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
         }
+    
+    
+    
 }
+
+extension UIColor {
+    convenience init(slideColor: SlideRGBColor) {
+        self.init(red: CGFloat(slideColor.red) / 255.0, green: CGFloat(slideColor.green) / 255.0, blue: CGFloat(slideColor.blue) / 255.0, alpha: 1.0)
+    }
+}
+
+

--- a/MyKeynote/MyKeynote/KeynoteViewController.swift
+++ b/MyKeynote/MyKeynote/KeynoteViewController.swift
@@ -10,9 +10,7 @@ import UIKit
 class KeynoteViewController: UIViewController {
 
     private var keynoteView : KeynoteView?
-    var slideManager = SlideManager(componentFactory: SlideComponentFactory(),
-                                    slideFactory: SlideFactory(),
-                                    slideCollection: SlideCollection())
+    private var slideManager : SlideManager
     
     
     
@@ -22,10 +20,11 @@ class KeynoteViewController: UIViewController {
     }
     
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
         slideManager = SlideManager(componentFactory: SlideComponentFactory(),
                                         slideFactory: SlideFactory(),
                                         slideCollection: SlideCollection())
+        super.init(coder: coder)
+        
         
     }
     
@@ -33,12 +32,15 @@ class KeynoteViewController: UIViewController {
         super.viewDidLoad()
         layout()
         keynoteView?.slideDataSource = self
-        attribute()
+        addObservers()
         loadInitialKeynoteState()
+        
         
     }
     
-    func layout(){
+
+    
+    private func layout(){
         keynoteView = KeynoteView()
         
         guard let keynoteView = keynoteView else { return }
@@ -52,15 +54,58 @@ class KeynoteViewController: UIViewController {
         keynoteView.layout()
         keynoteView.attribute()
     }
+
     
-    func attribute(){
-        
-    }
-    
-    func loadInitialKeynoteState(){
+    private func loadInitialKeynoteState(){
         slideManager.addSlide()
         slideManager.addElement(length: 200, backgroundColor: .init(red: 200, green: 200, blue: 200), type: RectangleElement.self)
         keynoteView?.reloadSlide()
+    }
+    
+   
+    private func addObservers() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateComponentAlpha(_:)),
+            name: NotificationName.transparencyChanged.notification ,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateComponentBackgroundColor(_:)),
+            name: NotificationName.backgroundColorChanged.notification ,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateSelectedElement(_:)),
+            name: NotificationName.changeSelectedElementId.notification ,
+            object: nil
+        )
+    }
+    
+    
+    @objc func updateComponentAlpha(_ notification: Notification) {
+        if let alpha = notification.object as? AlphaLevel {
+            slideManager.updateElementAlpha(alpha: alpha)
+        }
+    }
+    
+    @objc func updateComponentBackgroundColor(_ notification: Notification) {
+        if let rgbColor = notification.object as? SlideRGBColor {
+            slideManager.updateElementBackgroundColor(rgbColor: rgbColor)
+            keynoteView?.reloadSlide()
+            
+        }
+    }
+    
+    @objc func updateSelectedElement(_ notification: Notification) {
+        
+        if let id = notification.object as? String {
+            slideManager.updateSelectedElement(id: id)
+            keynoteView?.reloadSlide()
+            
+        }
     }
 }
 

--- a/MyKeynote/MyKeynote/Model/Element/BaseElement.swift
+++ b/MyKeynote/MyKeynote/Model/Element/BaseElement.swift
@@ -12,7 +12,6 @@ class BaseElement: SlideElementProtocol {
     let id: String
     var size: CGSize
     var backgroundColor: SlideRGBColor
-    var animation: AnimationApplicable?
     var alpha: AlphaLevel
     
     //Selectable
@@ -25,21 +24,26 @@ class BaseElement: SlideElementProtocol {
     var orderIndex: Int = 0
     
     required init(id : String, position: CGPoint, size: CGSize) {
-        self.id = id
-        self.position = position
-        self.size = size
-        backgroundColor =  .init(red: 222, green: 222, blue: 0)
-        alpha = .level10
-    }
+            self.id = id
+            self.position = position
+            self.size = size
+            backgroundColor =  .init(red: 222, green: 222, blue: 0)
+            alpha = .level10
+        }
     
-    init(id : String, position: CGPoint, size: CGSize, animation: AnimationApplicable? = nil) {
-        self.id = id
-        self.position = position
-        self.size = size
-        self.animation = animation
-        backgroundColor =  .init(red: 222, green: 222, blue: 222)
-        alpha = .level1
-    }
+    init(id : String,
+            position: CGPoint,
+            size: CGSize,
+            backgroundColor: SlideRGBColor = .init(red: 222, green: 222, blue: 222),
+            alpha: AlphaLevel = .level1) {
+           
+           self.id = id
+           self.position = position
+           self.size = size
+           self.backgroundColor = backgroundColor
+           self.alpha = alpha
+       }
+    
     
     //Draggable
     func startDrag(at point: CGPoint) {

--- a/MyKeynote/MyKeynote/Model/Element/SlideElementProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/Element/SlideElementProtocol.swift
@@ -11,7 +11,6 @@ protocol SlideElementProtocol : Draggable, Selectable, Resizable, Order{
     var id: String { get }
     var size: CGSize { get set }
     var backgroundColor : SlideRGBColor {get set }
-    var animation: AnimationApplicable? { get set }
     var alpha : AlphaLevel{ get set }
 
 }

--- a/MyKeynote/MyKeynote/Model/Factory/ElementCollection.swift
+++ b/MyKeynote/MyKeynote/Model/Factory/ElementCollection.swift
@@ -22,4 +22,8 @@ struct ElementCollection {
         return elementArray.count
     }
     
+    func getElement(id: String) -> SlideElementProtocol? {
+        return elementArray.first(where: { $0.id == id })
+    }
+    
 }

--- a/MyKeynote/MyKeynote/Model/Manager/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/Manager/SlideManager.swift
@@ -10,6 +10,9 @@ protocol SlideManaging {
     var slideCount: Int { get }
     mutating func addSlide()
     mutating func addElement(length: Int, backgroundColor: SlideRGBColor, type: BaseElement.Type)
+    mutating func updateElementAlpha(alpha : AlphaLevel)
+    mutating func updateElementBackgroundColor(rgbColor : SlideRGBColor)
+    mutating func updateSelectedElement(id : String)
 }
 
 struct SlideManager : SlideManaging{
@@ -20,6 +23,7 @@ struct SlideManager : SlideManaging{
     var slideCollection : SlideCollection
     
     var selectedSlide : SlideProtocol?
+    var selectedElement : SlideElementProtocol?
     
     var slideCount : Int {
         return slideCollection.getCount()
@@ -27,10 +31,10 @@ struct SlideManager : SlideManaging{
     
     
     init(componentFactory: SlideComponentFactoryProtocol, slideFactory: SlideFactoryProtocol, slideCollection: SlideCollection) {
-            self.componentFactory = componentFactory
-            self.slideFactory = slideFactory
-            self.slideCollection = slideCollection
-        }
+        self.componentFactory = componentFactory
+        self.slideFactory = slideFactory
+        self.slideCollection = slideCollection
+    }
     
     
     mutating func addSlide(){
@@ -45,6 +49,21 @@ struct SlideManager : SlideManaging{
             return
         }
         slide.addElement(newComponent)
+    }
+    
+    mutating func updateElementAlpha(alpha : AlphaLevel){
+        selectedElement?.alpha = alpha
+    }
+    
+    mutating func updateElementBackgroundColor(rgbColor : SlideRGBColor){
+        selectedElement?.backgroundColor = rgbColor
+    }
+    
+    mutating func updateSelectedElement(id : String){
+        if let element = selectedSlide?.getElement(id: id){
+            self.selectedElement = element
+        }
+        
     }
     
     

--- a/MyKeynote/MyKeynote/Model/Notification/NotificationName.swift
+++ b/MyKeynote/MyKeynote/Model/Notification/NotificationName.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+enum NotificationName: String {
+    case backgroundColorChanged
+    case transparencyChanged
+    case changeSelectedElementId
+    
+    var notification: Notification.Name {
+        return Notification.Name(self.rawValue)
+    }
+}

--- a/MyKeynote/MyKeynote/Model/Notification/NotificationName.swift
+++ b/MyKeynote/MyKeynote/Model/Notification/NotificationName.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationName.swift
+//  MyKeynote
+//
+//  Created by KoJeongMin  on 2023/07/26.
+//
+
+import Foundation

--- a/MyKeynote/MyKeynote/Model/Slide/BaseSlide.swift
+++ b/MyKeynote/MyKeynote/Model/Slide/BaseSlide.swift
@@ -32,6 +32,10 @@ extension BaseSlide{
     func removeElement(_ element: SlideElementProtocol) {
         
     }
+    func getElement(id: String) -> SlideElementProtocol? {
+        return elements.getElement(id: id)
+    }
+    
 }
 
 //Order

--- a/MyKeynote/MyKeynote/Model/SlideContentManageable.swift
+++ b/MyKeynote/MyKeynote/Model/SlideContentManageable.swift
@@ -10,4 +10,5 @@ protocol SlideContentManageable {
     var elements: ElementCollection { get }
     func addElement(_ element: SlideElementProtocol)
     func removeElement(_ element: SlideElementProtocol)
+    func getElement(id : String) -> SlideElementProtocol? 
 }

--- a/MyKeynote/MyKeynote/Model/SlideRGBColor.swift
+++ b/MyKeynote/MyKeynote/Model/SlideRGBColor.swift
@@ -15,3 +15,5 @@ struct SlideRGBColor{
 
     
 }
+
+

--- a/MyKeynote/MyKeynote/SceneDelegate.swift
+++ b/MyKeynote/MyKeynote/SceneDelegate.swift
@@ -16,7 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
        
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = CompositionRoot.rootViewController
+        window?.rootViewController = CompositionRoot.shared.rootViewController
         window?.makeKeyAndVisible()
     }
 

--- a/MyKeynote/MyKeynote/View/InspectorView.swift
+++ b/MyKeynote/MyKeynote/View/InspectorView.swift
@@ -8,6 +8,9 @@
 import Foundation
 import UIKit
 //우측 인스펙터 뷰
+
+
+
 class InspectorView : UIView{
     
     private var backgroundTitleLabel : UILabel?
@@ -16,7 +19,7 @@ class InspectorView : UIView{
     private var opacityNumberLabel : UILabel?
     private var opacityButton : CustomStepperButton?
     
-    var selectedComponent: RectangleComponentView? {
+    var selectedComponent: BaseComponentView? {
         didSet {
             updateInspector()
         }
@@ -53,7 +56,7 @@ class InspectorView : UIView{
             return
         }
         
-        colorPickerButton?.backgroundColor = component.color
+        colorPickerButton?.backgroundColor = component.backgroundColor
         opacityNumberLabel?.text = String(format: "%.1f", component.alpha)
         colorPickerButton?.setTitle(component.backgroundColor?.rgbHex, for: .normal)
     }
@@ -130,6 +133,7 @@ class InspectorView : UIView{
                   let _ =  self?.selectedComponent else {
                 return
             }
+            NotificationCenter.default.post(name: NotificationName.transparencyChanged.notification, object: level)
             
             self?.opacityNumberLabel?.text = "\(level.rawValue)"
             self?.selectedComponent?.alpha = CGFloat(level.rawValue)
@@ -144,7 +148,7 @@ class InspectorView : UIView{
         }
         
         let colorPickerController = UIColorPickerViewController()
-        colorPickerController.selectedColor = component.color
+        colorPickerController.selectedColor = component.backgroundColor ?? .clear
         colorPickerController.delegate = self
         
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -166,9 +170,9 @@ extension InspectorView: UIColorPickerViewControllerDelegate {
         
         let selectedColor = viewController.selectedColor
         component.backgroundColor = selectedColor
+        NotificationCenter.default.post(name: NotificationName.backgroundColorChanged.notification, object: SlideRGBColor(color: selectedColor))
         colorPickerButton?.backgroundColor = selectedColor
         colorPickerButton?.setTitle(selectedColor.rgbHex, for: .normal)
-        //보색 적용해야하는 부분
         colorPickerButton?.setTitleColor(.black, for: .normal)
     }
 }

--- a/MyKeynote/MyKeynote/View/KeynoteView.swift
+++ b/MyKeynote/MyKeynote/View/KeynoteView.swift
@@ -122,7 +122,13 @@ class KeynoteView : UIView{
 
 
 extension KeynoteView : PresentationViewDelegate{
-    func didSelectComponent(_ component: RectangleComponentView?) {
+    func didSelectComponent(_ component: BaseComponentView?) {
         inspectorView?.selectedComponent = component
+        if let selectedId = component?.id{
+            NotificationCenter.default.post(name: NotificationName.changeSelectedElementId.notification, object: selectedId)
+       
+        }
+        
     }
 }
+

--- a/MyKeynote/MyKeynote/View/PresentationView.swift
+++ b/MyKeynote/MyKeynote/View/PresentationView.swift
@@ -9,24 +9,28 @@ import Foundation
 import UIKit
 //슬라이드가 표시되는 뷰
 protocol PresentationViewDelegate: AnyObject {
-    func didSelectComponent(_ component: RectangleComponentView?)
+    func didSelectComponent(_ component: BaseComponentView?)
 }
 
 class PresentationView : UIView{
     
     weak var delegate: PresentationViewDelegate?
     
-    private var componentViews: [String: RectangleComponentView] = [:]
+    private var componentViews: [String: BaseComponentView] = [:]
        
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        
+        
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
         self.addGestureRecognizer(tapRecognizer)
+        
+        
     }
     
     @objc func handleTap(_ recognizer: UITapGestureRecognizer) {
@@ -35,11 +39,12 @@ class PresentationView : UIView{
         let hitViews = self.subviews.filter { $0.frame.contains(location) }
         
         if let selectedView = hitViews.last as? RectangleComponentView {
-            selectedView.select()
+            
+            selectedView.updateSelectedState(isSelected: true)
             delegate?.didSelectComponent(selectedView)
         } else {
             for subview in self.subviews {
-                (subview as? RectangleComponentView)?.deselect()
+                (subview as? RectangleComponentView)?.updateSelectedState(isSelected: false)
                 delegate?.didSelectComponent(nil)
             }
         }
@@ -50,7 +55,7 @@ class PresentationView : UIView{
         if let existingComponentView = componentViews[component.id] {
             
             let size = component.size
-            
+            existingComponentView.configure(with: component)
             existingComponentView.frame = .init(x: 320,
                                                 y: 235,
                                                 width: size.width,


### PR DESCRIPTION
## 🤖 title
[고정민] - (3-3) 관찰자(Observer) 패턴

## 💭what 
- [x] 뷰컨트롤러에서 Notification observer 등록(색상 변경, 투명도 변경, 선택된 컴포넌트)하였습니다.
- [x] Notification를 받아서 SlideManager가 모델을 업데이트하도록 구현하였습니다. 
- [x] InspectorView 색상 변경, 투명도 변경 이벤트 발생 Notification 추가하였습니다.
- [x] NotificationName을 String값을 입력하며 발생하는 실수를 줄이고자 열거형으로 정의하였습니다.

## 💭PR 반영한 부분
- [x] Composition Root 수정
호출 시 인스턴스를 새롭게 생성하던 기존의 방식이 아닌 한번 생성된 인스턴스를 재사용하는 싱글톤 패턴으로 수정하였습니다.

- [x] 뷰와 모델 분리
BaseComponentView 뷰로부터 element(모델)를 속성으로 가지고 있는 코드를 제거하였습니다.

- [x] BaseElement 공통적인 속성을 제외한 속성 제거
Animation과 같은 바로 쓰이지 않는 속성은 선언되지않도록 하였습니다. 처음 설계할 때 Element를 가장 상위의 protocol로 생각하지 않고 반대로 Selectable, Resizable과 같은 프로토콜이 더 추상화된 프로토콜이라고 생각하고 구현하였었습니다. 이것이 원인이 되어 현재 BaseElement가 처음부터 많은 공통기능을 가지게 되어버린 것 같습니다. 시간이 부족할 것 같아서 이부분은 다음 과제를 진행하면서 수정해보려고 합니다.

- [x] 불필요한 코드 제거
a. KeynoteViewController의 slideManager 속성이 두번 초기화 되는 코드 수정.
b. 이미 backgroundColor 접근이 가능한데도 추가된 color 속성 제거

- [x] CustomStepper 수정 시도
UIVIew로 커스텀하는 것이 아닌 UIStepper를 상속받아서 IntrinsicContentSize를 변경하여 크기와 디자인을 커스텀하려고 하였으나 반응이 없었고 방법을 찾지 못하여 실패하였습니다.

## 학습 키워드
- UIStepper
- IntrinsicContentSize
- NotificationCenter
- Publisher/Observer Pattern
- Dependency Injection
- Composition Root



   

## 🎁 결과 시연
![3-2결과](https://github.com/softeerbootcamp-2nd/ios-keynote/assets/68258365/45f1d25f-405d-4314-a2a6-3cb21911b193)
