### PR TITLE
[조승기] 슬라이드 목록 표시

### DIFF
--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7651B60A2A6BDF340098B75D /* IDServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C363759D2A6546F500AE6121 /* IDServiceProtocol.swift */; };
 		7651B60C2A6BED750098B75D /* MockRectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60B2A6BED750098B75D /* MockRectFactory.swift */; };
 		7651B60D2A6D131B0098B75D /* OneToTen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36375952A6526EA00AE6121 /* OneToTen.swift */; };
+		7651B60F2A6E3DAF0098B75D /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60E2A6E3DAF0098B75D /* CanvasView.swift */; };
 		76781CA12A66B4A2006B8B6B /* SlideManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA02A66B4A2006B8B6B /* SlideManager.swift */; };
 		76781CA32A66B50A006B8B6B /* RectFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */; };
 		76781CA52A66C451006B8B6B /* SlideManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA42A66C451006B8B6B /* SlideManagerProtocol.swift */; };
@@ -69,6 +70,7 @@
 
 /* Begin PBXFileReference section */
 		7651B60B2A6BED750098B75D /* MockRectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRectFactory.swift; sourceTree = "<group>"; };
+		7651B60E2A6E3DAF0098B75D /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		76781CA02A66B4A2006B8B6B /* SlideManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManager.swift; sourceTree = "<group>"; };
 		76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectFactoryProtocol.swift; sourceTree = "<group>"; };
 		76781CA42A66C451006B8B6B /* SlideManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManagerProtocol.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				76781CA62A66C8B5006B8B6B /* ControlStackView.swift */,
 				76781CA82A66CAAA006B8B6B /* ColorControlView.swift */,
 				76781CAA2A6764C8006B8B6B /* AlphaControlView.swift */,
+				7651B60E2A6E3DAF0098B75D /* CanvasView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -383,6 +386,7 @@
 				C36375942A64EBE400AE6121 /* SKColor.swift in Sources */,
 				C36375922A64EAD100AE6121 /* Rectable.swift in Sources */,
 				76781CB32A6967DE006B8B6B /* SKPoint.swift in Sources */,
+				7651B60F2A6E3DAF0098B75D /* CanvasView.swift in Sources */,
 				76781CB12A6957F8006B8B6B /* Colorful.swift in Sources */,
 				76781CA92A66CAAA006B8B6B /* ColorControlView.swift in Sources */,
 				76781CA52A66C451006B8B6B /* SlideManagerProtocol.swift in Sources */,

--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		76101C1F2A6FE65E006E5BAF /* SlideCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76101C1E2A6FE65E006E5BAF /* SlideCell.swift */; };
+		76101C212A6FEC6F006E5BAF /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76101C202A6FEC6F006E5BAF /* UIImage+.swift */; };
 		7651B5FF2A6BDF250098B75D /* SlideManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA02A66B4A2006B8B6B /* SlideManager.swift */; };
 		7651B6002A6BDF250098B75D /* SKPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CB22A6967DE006B8B6B /* SKPoint.swift */; };
 		7651B6012A6BDF250098B75D /* RectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36375972A652B7A00AE6121 /* RectFactory.swift */; };
@@ -73,6 +74,7 @@
 
 /* Begin PBXFileReference section */
 		76101C1E2A6FE65E006E5BAF /* SlideCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideCell.swift; sourceTree = "<group>"; };
+		76101C202A6FEC6F006E5BAF /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		7651B60B2A6BED750098B75D /* MockRectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRectFactory.swift; sourceTree = "<group>"; };
 		7651B60E2A6E3DAF0098B75D /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		7651B6102A6E6C680098B75D /* SKID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKID.swift; sourceTree = "<group>"; };
@@ -245,6 +247,7 @@
 				76781CB82A69940B006B8B6B /* UIColor+.swift */,
 				76781CBA2A6997B4006B8B6B /* UIView+.swift */,
 				7651B6122A6E71750098B75D /* NotificationName.swift */,
+				76101C202A6FEC6F006E5BAF /* UIImage+.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 				76101C1F2A6FE65E006E5BAF /* SlideCell.swift in Sources */,
 				76781CAB2A6764C8006B8B6B /* AlphaControlView.swift in Sources */,
 				76781CB52A697BBE006B8B6B /* Rect.swift in Sources */,
+				76101C212A6FEC6F006E5BAF /* UIImage+.swift in Sources */,
 				76781CA12A66B4A2006B8B6B /* SlideManager.swift in Sources */,
 				76781CA72A66C8B5006B8B6B /* ControlStackView.swift in Sources */,
 				C36375A02A65805900AE6121 /* Logger+.swift in Sources */,

--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		76101C1F2A6FE65E006E5BAF /* SlideCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76101C1E2A6FE65E006E5BAF /* SlideCell.swift */; };
 		7651B5FF2A6BDF250098B75D /* SlideManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA02A66B4A2006B8B6B /* SlideManager.swift */; };
 		7651B6002A6BDF250098B75D /* SKPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CB22A6967DE006B8B6B /* SKPoint.swift */; };
 		7651B6012A6BDF250098B75D /* RectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36375972A652B7A00AE6121 /* RectFactory.swift */; };
@@ -71,6 +72,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		76101C1E2A6FE65E006E5BAF /* SlideCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideCell.swift; sourceTree = "<group>"; };
 		7651B60B2A6BED750098B75D /* MockRectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRectFactory.swift; sourceTree = "<group>"; };
 		7651B60E2A6E3DAF0098B75D /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		7651B6102A6E6C680098B75D /* SKID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKID.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				76781CA82A66CAAA006B8B6B /* ColorControlView.swift */,
 				76781CAA2A6764C8006B8B6B /* AlphaControlView.swift */,
 				7651B60E2A6E3DAF0098B75D /* CanvasView.swift */,
+				76101C1E2A6FE65E006E5BAF /* SlideCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 				7651B6112A6E6C680098B75D /* SKID.swift in Sources */,
 				76781CA32A66B50A006B8B6B /* RectFactoryProtocol.swift in Sources */,
 				C363759C2A6538DA00AE6121 /* IDService.swift in Sources */,
+				76101C1F2A6FE65E006E5BAF /* SlideCell.swift in Sources */,
 				76781CAB2A6764C8006B8B6B /* AlphaControlView.swift in Sources */,
 				76781CB52A697BBE006B8B6B /* Rect.swift in Sources */,
 				76781CA12A66B4A2006B8B6B /* SlideManager.swift in Sources */,

--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		7651B60D2A6D131B0098B75D /* OneToTen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36375952A6526EA00AE6121 /* OneToTen.swift */; };
 		7651B60F2A6E3DAF0098B75D /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60E2A6E3DAF0098B75D /* CanvasView.swift */; };
 		7651B6112A6E6C680098B75D /* SKID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B6102A6E6C680098B75D /* SKID.swift */; };
-		7651B6132A6E71750098B75D /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B6122A6E71750098B75D /* NotificationName.swift */; };
+		76741EE42A7221DF00F99D55 /* SKID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B6102A6E6C680098B75D /* SKID.swift */; };
 		76781CA12A66B4A2006B8B6B /* SlideManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA02A66B4A2006B8B6B /* SlideManager.swift */; };
 		76781CA32A66B50A006B8B6B /* RectFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */; };
 		76781CA52A66C451006B8B6B /* SlideManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA42A66C451006B8B6B /* SlideManagerProtocol.swift */; };
@@ -78,7 +78,6 @@
 		7651B60B2A6BED750098B75D /* MockRectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRectFactory.swift; sourceTree = "<group>"; };
 		7651B60E2A6E3DAF0098B75D /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		7651B6102A6E6C680098B75D /* SKID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKID.swift; sourceTree = "<group>"; };
-		7651B6122A6E71750098B75D /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		76781CA02A66B4A2006B8B6B /* SlideManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManager.swift; sourceTree = "<group>"; };
 		76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectFactoryProtocol.swift; sourceTree = "<group>"; };
 		76781CA42A66C451006B8B6B /* SlideManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManagerProtocol.swift; sourceTree = "<group>"; };
@@ -246,7 +245,6 @@
 				C363759F2A65805900AE6121 /* Logger+.swift */,
 				76781CB82A69940B006B8B6B /* UIColor+.swift */,
 				76781CBA2A6997B4006B8B6B /* UIView+.swift */,
-				7651B6122A6E71750098B75D /* NotificationName.swift */,
 				76101C202A6FEC6F006E5BAF /* UIImage+.swift */,
 			);
 			path = Util;
@@ -407,7 +405,6 @@
 				76781CA52A66C451006B8B6B /* SlideManagerProtocol.swift in Sources */,
 				C363755B2A64DF8500AE6121 /* SceneDelegate.swift in Sources */,
 				C36375962A6526EA00AE6121 /* OneToTen.swift in Sources */,
-				7651B6132A6E71750098B75D /* NotificationName.swift in Sources */,
 				76781CB92A69940B006B8B6B /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -416,6 +413,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				76741EE42A7221DF00F99D55 /* SKID.swift in Sources */,
 				7651B60A2A6BDF340098B75D /* IDServiceProtocol.swift in Sources */,
 				7651B6092A6BDF340098B75D /* IDService.swift in Sources */,
 				7651B6042A6BDF250098B75D /* Rect.swift in Sources */,

--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		7651B60C2A6BED750098B75D /* MockRectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60B2A6BED750098B75D /* MockRectFactory.swift */; };
 		7651B60D2A6D131B0098B75D /* OneToTen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36375952A6526EA00AE6121 /* OneToTen.swift */; };
 		7651B60F2A6E3DAF0098B75D /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60E2A6E3DAF0098B75D /* CanvasView.swift */; };
+		7651B6112A6E6C680098B75D /* SKID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B6102A6E6C680098B75D /* SKID.swift */; };
 		7651B6132A6E71750098B75D /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B6122A6E71750098B75D /* NotificationName.swift */; };
 		76781CA12A66B4A2006B8B6B /* SlideManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA02A66B4A2006B8B6B /* SlideManager.swift */; };
 		76781CA32A66B50A006B8B6B /* RectFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */; };
@@ -72,6 +73,7 @@
 /* Begin PBXFileReference section */
 		7651B60B2A6BED750098B75D /* MockRectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRectFactory.swift; sourceTree = "<group>"; };
 		7651B60E2A6E3DAF0098B75D /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
+		7651B6102A6E6C680098B75D /* SKID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKID.swift; sourceTree = "<group>"; };
 		7651B6122A6E71750098B75D /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		76781CA02A66B4A2006B8B6B /* SlideManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManager.swift; sourceTree = "<group>"; };
 		76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectFactoryProtocol.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 		C36375882A64E54700AE6121 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				7651B6102A6E6C680098B75D /* SKID.swift */,
 				76781CB22A6967DE006B8B6B /* SKPoint.swift */,
 				C36375932A64EBE400AE6121 /* SKColor.swift */,
 				76781CB02A6957F8006B8B6B /* Colorful.swift */,
@@ -373,6 +376,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7651B6112A6E6C680098B75D /* SKID.swift in Sources */,
 				76781CA32A66B50A006B8B6B /* RectFactoryProtocol.swift in Sources */,
 				C363759C2A6538DA00AE6121 /* IDService.swift in Sources */,
 				76781CAB2A6764C8006B8B6B /* AlphaControlView.swift in Sources */,

--- a/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
+++ b/MyKeynote/MyKeynote.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		7651B60C2A6BED750098B75D /* MockRectFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60B2A6BED750098B75D /* MockRectFactory.swift */; };
 		7651B60D2A6D131B0098B75D /* OneToTen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36375952A6526EA00AE6121 /* OneToTen.swift */; };
 		7651B60F2A6E3DAF0098B75D /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B60E2A6E3DAF0098B75D /* CanvasView.swift */; };
+		7651B6132A6E71750098B75D /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7651B6122A6E71750098B75D /* NotificationName.swift */; };
 		76781CA12A66B4A2006B8B6B /* SlideManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA02A66B4A2006B8B6B /* SlideManager.swift */; };
 		76781CA32A66B50A006B8B6B /* RectFactoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */; };
 		76781CA52A66C451006B8B6B /* SlideManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76781CA42A66C451006B8B6B /* SlideManagerProtocol.swift */; };
@@ -71,6 +72,7 @@
 /* Begin PBXFileReference section */
 		7651B60B2A6BED750098B75D /* MockRectFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRectFactory.swift; sourceTree = "<group>"; };
 		7651B60E2A6E3DAF0098B75D /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
+		7651B6122A6E71750098B75D /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		76781CA02A66B4A2006B8B6B /* SlideManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManager.swift; sourceTree = "<group>"; };
 		76781CA22A66B50A006B8B6B /* RectFactoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectFactoryProtocol.swift; sourceTree = "<group>"; };
 		76781CA42A66C451006B8B6B /* SlideManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideManagerProtocol.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				C363759F2A65805900AE6121 /* Logger+.swift */,
 				76781CB82A69940B006B8B6B /* UIColor+.swift */,
 				76781CBA2A6997B4006B8B6B /* UIView+.swift */,
+				7651B6122A6E71750098B75D /* NotificationName.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				76781CA52A66C451006B8B6B /* SlideManagerProtocol.swift in Sources */,
 				C363755B2A64DF8500AE6121 /* SceneDelegate.swift in Sources */,
 				C36375962A6526EA00AE6121 /* OneToTen.swift in Sources */,
+				7651B6132A6E71750098B75D /* NotificationName.swift in Sources */,
 				76781CB92A69940B006B8B6B /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MyKeynote/MyKeynote/Model/Rect.swift
+++ b/MyKeynote/MyKeynote/Model/Rect.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class Rect: Rectable, Colorful {
-    let id: String
+    let id: SKID
     var point: SKPoint
     var height: Int
     var aspectRatio: Double { 4.0 / 3.0 }
@@ -17,7 +17,7 @@ class Rect: Rectable, Colorful {
     
     var description: String { "(\(id)), Height:\(height), \(color.description), Alpha:\(String(format: "%2d", alpha))" }
     
-    required init(id: String, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data? = nil) {
+    required init(id: SKID, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data? = nil) {
         self.id = id
         self.point = point
         self.height = height

--- a/MyKeynote/MyKeynote/Model/Rect.swift
+++ b/MyKeynote/MyKeynote/Model/Rect.swift
@@ -13,6 +13,7 @@ class Rect: Rectable, Colorful {
     var height: Int
     var aspectRatio: Double { 4.0 / 3.0 }
     var color: SKColor
+    var isSelected: Bool
     @OneToTen var alpha: Int
     
     var description: String { "(\(id)), Height:\(height), \(color.description), Alpha:\(String(format: "%2d", alpha))" }
@@ -23,5 +24,6 @@ class Rect: Rectable, Colorful {
         self.height = height
         self.alpha = alpha
         self.color = color ?? SKColor.randomOne()
+        isSelected = false
     }
 }

--- a/MyKeynote/MyKeynote/Model/Rect.swift
+++ b/MyKeynote/MyKeynote/Model/Rect.swift
@@ -9,21 +9,18 @@ import Foundation
 
 class Rect: Rectable, Colorful {
     let id: SKID
-    var point: SKPoint
     var height: Int
     var aspectRatio: Double { 4.0 / 3.0 }
     var color: SKColor
-    var isSelected: Bool
+    var isSelected: Bool = false
     @OneToTen var alpha: Int
     
     var description: String { "(\(id)), Height:\(height), \(color.description), Alpha:\(String(format: "%2d", alpha))" }
     
-    required init(id: SKID, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data? = nil) {
+    required init(id: SKID, height: Int, alpha: Int, color: SKColor) {
         self.id = id
-        self.point = point
         self.height = height
         self.alpha = alpha
-        self.color = color ?? SKColor.randomOne()
-        isSelected = false
+        self.color = color
     }
 }

--- a/MyKeynote/MyKeynote/Model/RectFactory.swift
+++ b/MyKeynote/MyKeynote/Model/RectFactory.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 class RectFactory: RectFactoryProtocol {
-    private var maxPoint = SKPoint(x: 500, y: 400)
-    
     private let idService: IDServiceProtocol
     private var randomNumberGenerator: RandomNumberGenerator
     
@@ -17,19 +15,11 @@ class RectFactory: RectFactoryProtocol {
         self.idService = idService
         self.randomNumberGenerator = randomNumberGenerator
     }
-    
-    func changeMaxPoint(_ point: SKPoint) {
-        guard point.x > 0 && point.y > 0 else { return }
-        maxPoint = point
-    }
-    
-    func make<T: Rectable>(by type: T.Type, photo: Data? = nil) -> T {
-        type.init(id: idService.makeNewID(),
-                  point: SKPoint(x: Double.random(in: 0...(maxPoint.x), using: &randomNumberGenerator),
-                                 y: Double.random(in: 0...(maxPoint.y), using: &randomNumberGenerator)),
-                  height: Int.random(in: 100...300, using: &randomNumberGenerator),
-                  alpha: Int.random(in: 1...10, using: &randomNumberGenerator),
-                  color: SKColor.randomOne(),
-                  photo: photo)
+
+    func makeSquare() -> Square {
+        Square(id: idService.makeNewID(),
+               height: Int.random(in: 100...300, using: &randomNumberGenerator),
+               alpha: Int.random(in: 1...10, using: &randomNumberGenerator),
+               color: SKColor.randomOne())
     }
 }

--- a/MyKeynote/MyKeynote/Model/RectFactoryProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/RectFactoryProtocol.swift
@@ -8,6 +8,5 @@
 import Foundation
 
 protocol RectFactoryProtocol {
-    func changeMaxPoint(_ point: SKPoint)
-    func make<T: Rectable>(by type: T.Type, photo: Data?) -> T
+    func makeSquare() -> Square 
 }

--- a/MyKeynote/MyKeynote/Model/Rectable.swift
+++ b/MyKeynote/MyKeynote/Model/Rectable.swift
@@ -9,7 +9,6 @@ import Foundation
 
 protocol Rectable: CustomStringConvertible {
     var id: String { get }
-    var point: SKPoint { get set }
     var height: Int { get set }
     var aspectRatio: Double { get }
     var alpha: Int { get set }
@@ -26,7 +25,9 @@ extension Rectable {
         Double(height) * aspectRatio
     }
     
-    func contains(point: SKPoint) -> Bool {
-        (self.point.x...self.point.x+getWidth()) ~= point.x && (self.point.y...self.point.y+getWidth()) ~= point.y
+    func contains(point: SKPoint, where center: SKPoint) -> Bool {
+        let isXInRange = (center.x - getWidth() / 2)...(center.x + getWidth() / 2) ~= point.x
+        let isYInRange = (center.y - Double(height) / 2)...(center.y + Double(height) / 2) ~= point.y
+        return isXInRange && isYInRange
     }
 }

--- a/MyKeynote/MyKeynote/Model/Rectable.swift
+++ b/MyKeynote/MyKeynote/Model/Rectable.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 protocol Rectable: CustomStringConvertible {
-    var id: String { get }
+    var id: SKID { get }
     var height: Int { get set }
     var aspectRatio: Double { get }
     var alpha: Int { get set }
     
-    init(id: String, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data?)
+    init(id: SKID, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data?)
 }
 
 extension Rectable {

--- a/MyKeynote/MyKeynote/Model/Rectable.swift
+++ b/MyKeynote/MyKeynote/Model/Rectable.swift
@@ -31,4 +31,8 @@ extension Rectable {
         let isYInRange = (center.y - Double(height) / 2)...(center.y + Double(height) / 2) ~= point.y
         return isXInRange && isYInRange
     }
+    
+    mutating func changeAlpha(to alpha: Int) {
+        self.alpha = alpha
+    }
 }

--- a/MyKeynote/MyKeynote/Model/Rectable.swift
+++ b/MyKeynote/MyKeynote/Model/Rectable.swift
@@ -12,6 +12,7 @@ protocol Rectable: CustomStringConvertible {
     var height: Int { get set }
     var aspectRatio: Double { get }
     var alpha: Int { get set }
+    var isSelected: Bool { get set }
     
     init(id: SKID, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data?)
 }

--- a/MyKeynote/MyKeynote/Model/Rectable.swift
+++ b/MyKeynote/MyKeynote/Model/Rectable.swift
@@ -13,8 +13,6 @@ protocol Rectable: CustomStringConvertible {
     var aspectRatio: Double { get }
     var alpha: Int { get set }
     var isSelected: Bool { get set }
-    
-    init(id: SKID, point: SKPoint, height: Int, alpha: Int, color: SKColor?, photo: Data?)
 }
 
 extension Rectable {

--- a/MyKeynote/MyKeynote/Model/SKColor.swift
+++ b/MyKeynote/MyKeynote/Model/SKColor.swift
@@ -21,7 +21,8 @@ class SKColor: CustomStringConvertible {
     var description: String { "R:\(red), G:\(green), B:\(blue)" }
     
     func toHex() -> String {
-        "0x\(String(red, radix: 16))\(String(green, radix: 16))\(String(blue, radix: 16))"
+        String(format: "0x%02X%02X%02X", red, green, blue)
+    }
     }
     
     func complementaryColor() -> SKColor {

--- a/MyKeynote/MyKeynote/Model/SKColor.swift
+++ b/MyKeynote/MyKeynote/Model/SKColor.swift
@@ -23,6 +23,9 @@ class SKColor: CustomStringConvertible {
     func toHex() -> String {
         String(format: "0x%02X%02X%02X", red, green, blue)
     }
+    
+    func toDoubleRgb() -> (Double, Double, Double) {
+        (Double(red) / 255, Double(green) / 255, Double(blue) / 255)
     }
     
     func complementaryColor() -> SKColor {

--- a/MyKeynote/MyKeynote/Model/SKID.swift
+++ b/MyKeynote/MyKeynote/Model/SKID.swift
@@ -1,0 +1,24 @@
+//
+//  SKID.swift
+//  MyKeynote
+//
+//  Created by 조승기 on 2023/07/24.
+//
+
+import Foundation
+
+struct SKID {
+    var id: String
+    
+    var toInt: Int { id.hashValue }
+}
+
+extension SKID: Equatable {
+    static func == (lhs: SKID, rhs: SKID) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+extension SKID: Hashable {
+    var hashValue: Int { id.hashValue }
+}

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -33,8 +33,8 @@ class SlideManager: SlideManagerProtocol {
         (0..<slides.count) ~= i ? slides[i] : nil
     }
     
-    func makeRect<T: Rectable>(by type: T.Type, photo: Data? = nil) {
-        let newRect = rectFactory.make(by: type, photo: photo)
+    func makeSquare() {
+        let newRect = rectFactory.makeSquare()
         slides.append(newRect)
         
         currentTableIndex = count - 1

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -14,6 +14,7 @@ class SlideManager: SlideManagerProtocol {
     //MARK: - Property
     private var slides: [Rectable] = []
     var count: Int { slides.count }
+    var currentIndex: Int? = 0
     
     //MARK: - Lifecycle
     init(rectFactory: RectFactoryProtocol) {
@@ -31,12 +32,22 @@ class SlideManager: SlideManagerProtocol {
     }
     
     func changeAlpha(to alpha: Int) {
+        guard let index = currentIndex else { return }
+        slides[index].alpha = alpha
+        NotificationCenter.default.post(name: .slideAlphaChanged, object: self, userInfo: ["slide": slides[index]])
     }
     
     func changeColor(to color: SKColor) {
+        guard let index = currentIndex,
+              var rect = slides[index] as? Colorful else { return }
         rect.color = color
+        NotificationCenter.default.post(name: .rectColorChanged, object: self, userInfo: ["rect": rect])
     }
     
     func tapped(at point: SKPoint, center: SKPoint) {
+        guard let index = currentIndex else { return }
+        let slide = slides[index]
+        let selectedRect = slide.contains(point: point, where: center) ? slide : nil
+        NotificationCenter.default.post(name: .selectedRectChanged, object: self, userInfo: ["selectedRect": selectedRect])
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -51,8 +51,6 @@ struct SlideManager: SlideManagerProtocol {
         changed?(rect)
     }
     
-    mutating func tapped(at point: SKPoint) {
-        selectedRect = slides.last(where: { $0.contains(point: point) })
     mutating func tapped(at point: SKPoint, center: SKPoint) {
         let currentSlide = slides[currentSlideIndex]
         selectedRect = currentSlide.contains(point: point, where: center) ? currentSlide : nil

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -13,6 +13,7 @@ struct SlideManager: SlideManagerProtocol {
     
     //MARK: - Property
     private var slides: [Rectable] = []
+    private var currentSlideIndex = 0
     private var selectedRect: Rectable? {
         willSet {
             selectedRectDidChanged?(newValue)
@@ -52,5 +53,8 @@ struct SlideManager: SlideManagerProtocol {
     
     mutating func tapped(at point: SKPoint) {
         selectedRect = slides.last(where: { $0.contains(point: point) })
+    mutating func tapped(at point: SKPoint, center: SKPoint) {
+        let currentSlide = slides[currentSlideIndex]
+        selectedRect = currentSlide.contains(point: point, where: center) ? currentSlide : nil
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 class SlideManager: SlideManagerProtocol {
+    enum Notifications {
+        static let selectedRectChanged = Notification.Name("selectedRectChanged")
+        static let rectColorChanged = Notification.Name("rectColorChanged")
+        static let slideAlphaChanged = Notification.Name("slideAlphaChanged")
+        static let squareMade = Notification.Name("squareMade")
+        static let tableIndexChanged = Notification.Name("tableIndexChanged")
+    }
     //MARK: - Dependency
     private let rectFactory: RectFactoryProtocol
     
@@ -31,34 +38,34 @@ class SlideManager: SlideManagerProtocol {
         slides.append(newRect)
         
         currentTableIndex = count - 1
-        NotificationCenter.default.post(name: .squareMade, object: self, userInfo: ["slide": newRect, "index": currentTableIndex])
+        NotificationCenter.default.post(name: SlideManager.Notifications.squareMade, object: self, userInfo: ["slide": newRect, "index": currentTableIndex])
     }
     
     func changeAlpha(to alpha: Int) {
         guard let index = currentTableIndex else { return }
         slides[index].alpha = alpha
-        NotificationCenter.default.post(name: .slideAlphaChanged, object: self, userInfo: ["slide": slides[index]])
+        NotificationCenter.default.post(name: SlideManager.Notifications.slideAlphaChanged, object: self, userInfo: ["slide": slides[index]])
     }
     
     func changeColor(to color: SKColor) {
         guard let index = currentTableIndex,
               var rect = slides[index] as? Colorful else { return }
         rect.color = color
-        NotificationCenter.default.post(name: .rectColorChanged, object: self, userInfo: ["rect": rect])
+        NotificationCenter.default.post(name: SlideManager.Notifications.rectColorChanged, object: self, userInfo: ["rect": rect])
     }
     
     func tapped(at point: SKPoint, center: SKPoint) {
         guard let index = currentTableIndex else { return }
         let slide = slides[index]
         let selectedRect = slide.contains(point: point, where: center) ? slide : nil
-        NotificationCenter.default.post(name: .selectedRectChanged, object: self, userInfo: ["selectedRect": selectedRect])
+        NotificationCenter.default.post(name: SlideManager.Notifications.selectedRectChanged, object: self, userInfo: ["selectedRect": selectedRect])
     }
     
     func changeTableIndex(to index: Int?) {
         currentTableIndex = index
         
         let slide = index != nil ? self[index!] : nil
-        NotificationCenter.default.post(name: .tableIndexChanged, object: self, userInfo: ["id": slide?.id])
-        NotificationCenter.default.post(name: .selectedRectChanged, object: self, userInfo: ["selectedRect": slide])
+        NotificationCenter.default.post(name: SlideManager.Notifications.tableIndexChanged, object: self, userInfo: ["id": slide?.id])
+        NotificationCenter.default.post(name: SlideManager.Notifications.selectedRectChanged, object: self, userInfo: ["selectedRect": slide])
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -9,11 +9,18 @@ import Foundation
 
 class SlideManager: SlideManagerProtocol {
     enum Notifications {
-        static let selectedRectChanged = Notification.Name("selectedRectChanged")
+        static let selectedSlideChanged = Notification.Name("selectedSlideChanged")
         static let rectColorChanged = Notification.Name("rectColorChanged")
         static let slideAlphaChanged = Notification.Name("slideAlphaChanged")
         static let squareMade = Notification.Name("squareMade")
         static let tableIndexChanged = Notification.Name("tableIndexChanged")
+    }
+    enum UserInfoKeys {
+        static let slide = "slide"
+        static let rect = "rect"
+        static let selectedSlide = "selectedSlide"
+        static let id = "id"
+        static let index = "index"
     }
     //MARK: - Dependency
     private let rectFactory: RectFactoryProtocol
@@ -38,34 +45,34 @@ class SlideManager: SlideManagerProtocol {
         slides.append(newRect)
         
         currentTableIndex = count - 1
-        NotificationCenter.default.post(name: SlideManager.Notifications.squareMade, object: self, userInfo: ["slide": newRect, "index": currentTableIndex])
+        NotificationCenter.default.post(name: SlideManager.Notifications.squareMade, object: self, userInfo: [UserInfoKeys.slide: newRect, UserInfoKeys.index: currentTableIndex])
     }
     
     func changeAlpha(to alpha: Int) {
         guard let index = currentTableIndex else { return }
         slides[index].alpha = alpha
-        NotificationCenter.default.post(name: SlideManager.Notifications.slideAlphaChanged, object: self, userInfo: ["slide": slides[index]])
+        NotificationCenter.default.post(name: SlideManager.Notifications.slideAlphaChanged, object: self, userInfo: [UserInfoKeys.slide: slides[index]])
     }
     
     func changeColor(to color: SKColor) {
         guard let index = currentTableIndex,
               var rect = slides[index] as? Colorful else { return }
         rect.color = color
-        NotificationCenter.default.post(name: SlideManager.Notifications.rectColorChanged, object: self, userInfo: ["rect": rect])
+        NotificationCenter.default.post(name: SlideManager.Notifications.rectColorChanged, object: self, userInfo: [UserInfoKeys.rect: rect])
     }
     
     func tapped(at point: SKPoint, center: SKPoint) {
         guard let index = currentTableIndex else { return }
         let slide = slides[index]
-        let selectedRect = slide.contains(point: point, where: center) ? slide : nil
-        NotificationCenter.default.post(name: SlideManager.Notifications.selectedRectChanged, object: self, userInfo: ["selectedRect": selectedRect])
+        let selectedSlide = slide.contains(point: point, where: center) ? slide : nil
+        NotificationCenter.default.post(name: SlideManager.Notifications.selectedSlideChanged, object: self, userInfo: [UserInfoKeys.selectedSlide: selectedSlide])
     }
     
     func changeTableIndex(to index: Int?) {
         currentTableIndex = index
         
         let slide = index != nil ? self[index!] : nil
-        NotificationCenter.default.post(name: SlideManager.Notifications.tableIndexChanged, object: self, userInfo: ["id": slide?.id])
-        NotificationCenter.default.post(name: SlideManager.Notifications.selectedRectChanged, object: self, userInfo: ["selectedRect": slide])
+        NotificationCenter.default.post(name: SlideManager.Notifications.tableIndexChanged, object: self, userInfo: [UserInfoKeys.id: slide?.id])
+        NotificationCenter.default.post(name: SlideManager.Notifications.selectedSlideChanged, object: self, userInfo: [UserInfoKeys.slide: slide])
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct SlideManager: SlideManagerProtocol {
+class SlideManager: SlideManagerProtocol {
     //MARK: - Dependency
     private let rectFactory: RectFactoryProtocol
     
@@ -34,25 +34,25 @@ struct SlideManager: SlideManagerProtocol {
     subscript(i: Int) -> Rectable? {
         (0..<slides.count) ~= i ? slides[i] : nil
     }
-    mutating func makeRect<T: Rectable>(by type: T.Type, photo: Data? = nil) -> T {
+    func makeRect<T: Rectable>(by type: T.Type, photo: Data? = nil) -> T {
         let newRect = rectFactory.make(by: type, photo: photo)
         slides.append(newRect)
         return newRect
     }
     
-    mutating func changeAlpha(to alpha: Int) {
         selectedRect?.alpha = alpha
         changed?(selectedRect)
+    func changeAlpha(to alpha: Int) {
     }
     
-    mutating func changeColor(to color: SKColor) {
         guard let rect = selectedRect as? Rect else { return }
+    func changeColor(to color: SKColor) {
         rect.color = color
         changed?(rect)
     }
     
-    mutating func tapped(at point: SKPoint, center: SKPoint) {
         let currentSlide = slides[currentSlideIndex]
         selectedRect = currentSlide.contains(point: point, where: center) ? currentSlide : nil
+    func tapped(at point: SKPoint, center: SKPoint) {
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -13,8 +13,8 @@ class SlideManager: SlideManagerProtocol {
     
     //MARK: - Property
     private var slides: [Rectable] = []
+    private var currentTableIndex: Int?
     var count: Int { slides.count }
-    var currentIndex: Int? = 0
     
     //MARK: - Lifecycle
     init(rectFactory: RectFactoryProtocol) {
@@ -30,27 +30,35 @@ class SlideManager: SlideManagerProtocol {
         let newRect = rectFactory.make(by: type, photo: photo)
         slides.append(newRect)
         
-        currentIndex = count - 1
-        NotificationCenter.default.post(name: .squareMade, object: self, userInfo: ["slide": newRect, "index": currentIndex])
+        currentTableIndex = count - 1
+        NotificationCenter.default.post(name: .squareMade, object: self, userInfo: ["slide": newRect, "index": currentTableIndex])
     }
     
     func changeAlpha(to alpha: Int) {
-        guard let index = currentIndex else { return }
+        guard let index = currentTableIndex else { return }
         slides[index].alpha = alpha
         NotificationCenter.default.post(name: .slideAlphaChanged, object: self, userInfo: ["slide": slides[index]])
     }
     
     func changeColor(to color: SKColor) {
-        guard let index = currentIndex,
+        guard let index = currentTableIndex,
               var rect = slides[index] as? Colorful else { return }
         rect.color = color
         NotificationCenter.default.post(name: .rectColorChanged, object: self, userInfo: ["rect": rect])
     }
     
     func tapped(at point: SKPoint, center: SKPoint) {
-        guard let index = currentIndex else { return }
+        guard let index = currentTableIndex else { return }
         let slide = slides[index]
         let selectedRect = slide.contains(point: point, where: center) ? slide : nil
         NotificationCenter.default.post(name: .selectedRectChanged, object: self, userInfo: ["selectedRect": selectedRect])
+    }
+    
+    func changeTableIndex(to index: Int?) {
+        currentTableIndex = index
+        
+        let slide = index != nil ? self[index!] : nil
+        NotificationCenter.default.post(name: .tableIndexChanged, object: self, userInfo: ["id": slide?.id])
+        NotificationCenter.default.post(name: .selectedRectChanged, object: self, userInfo: ["selectedRect": slide])
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -25,10 +25,13 @@ class SlideManager: SlideManagerProtocol {
     subscript(i: Int) -> Rectable? {
         (0..<slides.count) ~= i ? slides[i] : nil
     }
-    func makeRect<T: Rectable>(by type: T.Type, photo: Data? = nil) -> T {
+    
+    func makeRect<T: Rectable>(by type: T.Type, photo: Data? = nil) {
         let newRect = rectFactory.make(by: type, photo: photo)
         slides.append(newRect)
-        return newRect
+        
+        currentIndex = count - 1
+        NotificationCenter.default.post(name: .squareMade, object: self, userInfo: ["slide": newRect, "index": currentIndex])
     }
     
     func changeAlpha(to alpha: Int) {

--- a/MyKeynote/MyKeynote/Model/SlideManager.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManager.swift
@@ -13,17 +13,7 @@ class SlideManager: SlideManagerProtocol {
     
     //MARK: - Property
     private var slides: [Rectable] = []
-    private var currentSlideIndex = 0
-    private var selectedRect: Rectable? {
-        willSet {
-            selectedRectDidChanged?(newValue)
-        }
-    }
     var count: Int { slides.count }
-    
-    //MARK: - Output
-    var selectedRectDidChanged: ((Rectable?) -> ())?
-    var changed: ((Rectable?) -> ())?
     
     //MARK: - Lifecycle
     init(rectFactory: RectFactoryProtocol) {
@@ -40,19 +30,13 @@ class SlideManager: SlideManagerProtocol {
         return newRect
     }
     
-        selectedRect?.alpha = alpha
-        changed?(selectedRect)
     func changeAlpha(to alpha: Int) {
     }
     
-        guard let rect = selectedRect as? Rect else { return }
     func changeColor(to color: SKColor) {
         rect.color = color
-        changed?(rect)
     }
     
-        let currentSlide = slides[currentSlideIndex]
-        selectedRect = currentSlide.contains(point: point, where: center) ? currentSlide : nil
     func tapped(at point: SKPoint, center: SKPoint) {
     }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -9,9 +9,9 @@ import Foundation
 
 protocol SlideManagerProtocol {
     mutating func makeRect<T: Rectable>(by type: T.Type, photo: Data?) -> T
-    mutating func changeAlpha(to alpha: Int)
-    mutating func changeColor(to color: SKColor)
-    mutating func tapped(at point: SKPoint, center: SKPoint)
+    func changeAlpha(to alpha: Int)
+    func changeColor(to color: SKColor)
+    func tapped(at point: SKPoint, center: SKPoint)
     
     var count: Int { get }
     subscript(i: Int) -> Rectable? { get }

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -11,7 +11,7 @@ protocol SlideManagerProtocol {
     mutating func makeRect<T: Rectable>(by type: T.Type, photo: Data?) -> T
     mutating func changeAlpha(to alpha: Int)
     mutating func changeColor(to color: SKColor)
-    mutating func tapped(at point: SKPoint)
+    mutating func tapped(at point: SKPoint, center: SKPoint)
     
     var count: Int { get }
     subscript(i: Int) -> Rectable? { get }

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -7,11 +7,16 @@
 
 import Foundation
 
-protocol SlideManagerProtocol {
+protocol SlideManagerProtocol: SlideColorful {
+    mutating func makeRect<T: Rectable>(by type: T.Type, photo: Data?)
     func changeAlpha(to alpha: Int)
-    func changeColor(to color: SKColor)
+
     func tapped(at point: SKPoint, center: SKPoint)
     
     var count: Int { get }
     subscript(i: Int) -> Rectable? { get }
+}
+
+protocol SlideColorful {
+    func changeColor(to color: SKColor)
 }

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 protocol SlideManagerProtocol {
-    mutating func makeRect<T: Rectable>(by type: T.Type, photo: Data?) -> T
     func changeAlpha(to alpha: Int)
     func changeColor(to color: SKColor)
     func tapped(at point: SKPoint, center: SKPoint)

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -15,7 +15,4 @@ protocol SlideManagerProtocol {
     
     var count: Int { get }
     subscript(i: Int) -> Rectable? { get }
-    
-    var selectedRectDidChanged: ((Rectable?) -> ())? { get set }
-    var changed: ((Rectable?) -> ())? { get set }
 }

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -12,6 +12,7 @@ protocol SlideManagerProtocol: SlideColorful {
     func changeAlpha(to alpha: Int)
 
     func tapped(at point: SKPoint, center: SKPoint)
+    func changeTableIndex(to index: Int?)
     
     var count: Int { get }
     subscript(i: Int) -> Rectable? { get }

--- a/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
+++ b/MyKeynote/MyKeynote/Model/SlideManagerProtocol.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-protocol SlideManagerProtocol: SlideColorful {
-    mutating func makeRect<T: Rectable>(by type: T.Type, photo: Data?)
+protocol SlideManagerProtocol: SlideColorful, SlideMakeable {
     func changeAlpha(to alpha: Int)
 
     func tapped(at point: SKPoint, center: SKPoint)
@@ -20,4 +19,8 @@ protocol SlideManagerProtocol: SlideColorful {
 
 protocol SlideColorful {
     func changeColor(to color: SKColor)
+}
+
+protocol SlideMakeable {
+    func makeSquare()
 }

--- a/MyKeynote/MyKeynote/Util/IDService.swift
+++ b/MyKeynote/MyKeynote/Util/IDService.swift
@@ -14,12 +14,12 @@ class IDService: IDServiceProtocol {
     
     private init() {}
         
-    func makeNewID() -> String {
+    func makeNewID() -> SKID {
         let randomPool = "abcdefghijklmnopqrstuvwxyz0123456789".map{ String($0) }
         let randomArary = (0..<3).map { _ in (0..<3).map{ _ in randomPool[Int.random(in: 0..<randomPool.count)] }.joined() }
         let id = randomArary.joined(separator: "-")
-        IDs.insert(IDs.contains(id) ? makeNewID() : id)
-        return id
+        IDs.insert(IDs.contains(id) ? makeNewID().id : id)
+        return SKID(id: id)
     }
     
     static func toInt(_ id: String?) -> Int? {

--- a/MyKeynote/MyKeynote/Util/IDServiceProtocol.swift
+++ b/MyKeynote/MyKeynote/Util/IDServiceProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol IDServiceProtocol {
-    func makeNewID() -> String
+    func makeNewID() -> SKID
 }

--- a/MyKeynote/MyKeynote/Util/NotificationName.swift
+++ b/MyKeynote/MyKeynote/Util/NotificationName.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationName.swift
+//  MyKeynote
+//
+//  Created by 조승기 on 2023/07/24.
+//
+
+import Foundation

--- a/MyKeynote/MyKeynote/Util/NotificationName.swift
+++ b/MyKeynote/MyKeynote/Util/NotificationName.swift
@@ -1,8 +1,0 @@
-//
-//  NotificationName.swift
-//  MyKeynote
-//
-//  Created by 조승기 on 2023/07/24.
-//
-
-import Foundation

--- a/MyKeynote/MyKeynote/Util/UIImage+.swift
+++ b/MyKeynote/MyKeynote/Util/UIImage+.swift
@@ -5,4 +5,8 @@
 //  Created by 조승기 on 2023/07/25.
 //
 
-import Foundation
+import UIKit
+
+extension UIImage {
+    static let rectangleInsetFilled = UIImage(systemName: "rectangle.inset.filled")
+}

--- a/MyKeynote/MyKeynote/Util/UIImage+.swift
+++ b/MyKeynote/MyKeynote/Util/UIImage+.swift
@@ -1,0 +1,8 @@
+//
+//  UIImage+.swift
+//  MyKeynote
+//
+//  Created by 조승기 on 2023/07/25.
+//
+
+import Foundation

--- a/MyKeynote/MyKeynote/Util/UIView+.swift
+++ b/MyKeynote/MyKeynote/Util/UIView+.swift
@@ -22,7 +22,6 @@ extension UIView {
         var (red, green, blue): (CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0)
         backgroundColor?.getRed(&red, green: &green, blue: &blue, alpha: nil)
         backgroundColor = UIColor(red: red, green: green, blue: blue, alpha: alpha)
-        print(alpha)
     }
     
     func changeBackgroundColor(red: CGFloat, green: CGFloat, blue: CGFloat) {

--- a/MyKeynote/MyKeynote/Util/UIView+.swift
+++ b/MyKeynote/MyKeynote/Util/UIView+.swift
@@ -18,13 +18,16 @@ extension UIView {
         }
     }
     
-    func changeBackgroundColor(_ alpha: Int? = nil, _ skColor: SKColor? = nil) {
-        guard let skColor, let alpha else {
-            var alpha: CGFloat = 0.0
-            self.backgroundColor?.getRed(nil, green: nil, blue: nil, alpha: &alpha)
-            self.backgroundColor = UIColor.white.withAlphaComponent(alpha)
-            return
-        }
-        self.backgroundColor = UIColor(skColor: skColor, skAlpha: alpha)
+    func changeBackgroundAlpha(to alpha: CGFloat) {
+        var (red, green, blue): (CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0)
+        backgroundColor?.getRed(&red, green: &green, blue: &blue, alpha: nil)
+        backgroundColor = UIColor(red: red, green: green, blue: blue, alpha: alpha)
+        print(alpha)
+    }
+    
+    func changeBackgroundColor(red: CGFloat, green: CGFloat, blue: CGFloat) {
+        var alpha: CGFloat = 1.0
+        backgroundColor?.getRed(nil, green: nil, blue: nil, alpha: &alpha)
+        backgroundColor = UIColor(red: red, green: green, blue: blue, alpha: alpha)
     }
 }

--- a/MyKeynote/MyKeynote/View/AlphaControlView.swift
+++ b/MyKeynote/MyKeynote/View/AlphaControlView.swift
@@ -89,7 +89,7 @@ class AlphaControlView: UIView {
         alphaStepper.transform = CGAffineTransform(scaleX: 1.33, y: 1.36)
     }
     
-    func bind(skAlpha: Int?) {
+    func changeAlpha(to skAlpha: Int?) {
         guard let skAlpha else {
             alphaTextField.text = "0"
             alphaTextField.textColor = .gray

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -11,11 +11,11 @@ protocol CanvasViewDelegate: AnyObject {
     func canvasTapped(at point: CGPoint)
 }
 
-class CanvasView: UIView {
+class CanvasView: UIView { 
     // MARK: - UI properties
+    private var slide: UIView!
     
     // MARK: - Properties
-    var slides: [String: UIView] = [:]
     weak var delegate: CanvasViewDelegate?
     
     // MARK: - Lifecycles
@@ -31,25 +31,35 @@ class CanvasView: UIView {
         backgroundColor = .white
     }
     // MARK: - Helpers
-    func configureEvent() {
+    private func configureEvent() {
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(canvasTapped(sender:)))
         addGestureRecognizer(tapGestureRecognizer)
     }
     
-    @objc func canvasTapped(sender: UITapGestureRecognizer) {
+    @objc private func canvasTapped(sender: UITapGestureRecognizer) {
         delegate?.canvasTapped(at: sender.location(in: self))
     }
     
     func makeRectable(_ rectable: Rectable, color: UIColor? = nil) {
         let (width, height) = (rectable.getWidth(), Double(rectable.height))
-        let newView = UIView(frame: CGRect(x: bounds.midX - width / 2,
-                                           y: bounds.midY - height / 2,
-                                           width: width,
-                                           height: height))
-        newView.backgroundColor = color
-        slides[rectable.id] = newView
-        subviews.forEach { $0.isHidden = true }
-        newView.isSelected = true
-        addSubview(newView)
+        slide = UIView(frame: CGRect(x: bounds.midX - width / 2,
+                                     y: bounds.midY - height / 2,
+                                     width: width,
+                                     height: height))
+        slide.backgroundColor = color
+        tag = rectable.id.toInt
+        addSubview(slide)
+    }
+    
+    func changeSelection(to isSelected: Bool) {
+        slide.isSelected = isSelected
+    }
+    
+    func changeColor(red: CGFloat, green: CGFloat, blue: CGFloat) {
+        slide.changeBackgroundColor(red: red, green: green, blue: blue)
+    }
+    
+    func changeAlpha(to alpha: CGFloat) {
+        slide.changeBackgroundAlpha(to: alpha)
     }
 }

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -13,22 +13,23 @@ protocol CanvasViewDelegate: AnyObject {
 
 class CanvasView: UIView { 
     // MARK: - UI properties
-    private var slide: UIView!
-    
     // MARK: - Properties
     weak var delegate: CanvasViewDelegate?
+    private var slides: [SKID: UIView] = [:]
     
     // MARK: - Lifecycles
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureEvent()
         backgroundColor = .white
+        isHidden = true
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configureEvent()
         backgroundColor = .white
+        isHidden = true
     }
     // MARK: - Helpers
     private func configureEvent() {
@@ -49,6 +50,7 @@ class CanvasView: UIView {
         slide.backgroundColor = color
         tag = rectable.id.toInt
         addSubview(slide)
+        selectSlide(by: rectable.id)
     }
     
     func changeSelection(to isSelected: Bool) {
@@ -57,9 +59,16 @@ class CanvasView: UIView {
     
     func changeColor(red: CGFloat, green: CGFloat, blue: CGFloat) {
         slide.changeBackgroundColor(red: red, green: green, blue: blue)
+    func selectSlide(by id: SKID) {
+        isHidden = false
+        subviews.forEach { $0.isHidden = true }
+        slides[id]?.isHidden = false
     }
     
     func changeAlpha(to alpha: CGFloat) {
         slide.changeBackgroundAlpha(to: alpha)
+    func deselectSlide() {
+        self.isHidden = true
+        subviews.forEach { $0.isHidden = true }
     }
 }

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -19,19 +19,16 @@ class CanvasView: UIView {
     weak var delegate: CanvasViewDelegate?
     
     // MARK: - Lifecycles
-    private override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-    init(frame: CGRect, rectable: Rectable, color: UIColor? = nil) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
         configureEvent()
-        makeRectable(rectable, color: color)
         backgroundColor = .white
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         configureEvent()
+        backgroundColor = .white
     }
     // MARK: - Helpers
     func configureEvent() {
@@ -43,7 +40,7 @@ class CanvasView: UIView {
         delegate?.canvasTapped(at: sender.location(in: self))
     }
     
-    private func makeRectable(_ rectable: Rectable, color: UIColor? = nil) {
+    func makeRectable(_ rectable: Rectable, color: UIColor? = nil) {
         let (width, height) = (rectable.getWidth(), Double(rectable.height))
         let newView = UIView(frame: CGRect(x: bounds.midX - width / 2,
                                            y: bounds.midY - height / 2,
@@ -52,6 +49,7 @@ class CanvasView: UIView {
         newView.backgroundColor = color
         slides[rectable.id] = newView
         subviews.forEach { $0.isHidden = true }
+        newView.isSelected = true
         addSubview(newView)
     }
 }

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -1,0 +1,12 @@
+//
+//  CanvasView.swift
+//  MyKeynote
+//
+//  Created by 조승기 on 2023/07/24.
+//
+
+import UIKit
+
+class CanvasView: UIView {
+    
+}

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -7,6 +7,51 @@
 
 import UIKit
 
+protocol CanvasViewDelegate: AnyObject {
+    func canvasTapped(at point: CGPoint)
+}
+
 class CanvasView: UIView {
+    // MARK: - UI properties
     
+    // MARK: - Properties
+    var slides: [String: UIView] = [:]
+    weak var delegate: CanvasViewDelegate?
+    
+    // MARK: - Lifecycles
+    private override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    init(frame: CGRect, rectable: Rectable, color: UIColor? = nil) {
+        super.init(frame: frame)
+        configureEvent()
+        makeRectable(rectable, color: color)
+        backgroundColor = .white
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureEvent()
+    }
+    // MARK: - Helpers
+    func configureEvent() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(canvasTapped(sender:)))
+        addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc func canvasTapped(sender: UITapGestureRecognizer) {
+        delegate?.canvasTapped(at: sender.location(in: self))
+    }
+    
+    private func makeRectable(_ rectable: Rectable, color: UIColor? = nil) {
+        let (width, height) = (rectable.getWidth(), Double(rectable.height))
+        let newView = UIView(frame: CGRect(x: bounds.midX - width / 2,
+                                           y: bounds.midY - height / 2,
+                                           width: width,
+                                           height: height))
+        newView.backgroundColor = color
+        slides[rectable.id] = newView
+        subviews.forEach { $0.isHidden = true }
+        addSubview(newView)
+    }
 }

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -51,10 +51,15 @@ class CanvasView: UIView {
         tag = rectable.id.toInt
         addSubview(slide)
         selectSlide(by: rectable.id)
+        select(by: rectable.id, to: true)
     }
     
-    func changeSelection(to isSelected: Bool) {
-        slide.isSelected = isSelected
+    func select(by id: SKID, to isSelected: Bool) {
+        slides[id]?.isSelected = isSelected
+    }
+    
+    func deselect() {
+        slides.values.forEach { $0.isSelected = false }
     }
     
     func changeColor(red: CGFloat, green: CGFloat, blue: CGFloat) {

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -41,18 +41,17 @@ class CanvasView: UIView {
         delegate?.canvasTapped(at: sender.location(in: self))
     }
     
-    func makeRectable(_ rectable: Rectable, color: SKColor? = nil) {
-        let (width, height) = (rectable.getWidth(), Double(rectable.height))
+    func makeSlide(_ rect: Rectable & Colorful) {
+        let (width, height) = (rect.getWidth(), Double(rect.height))
         let slide = UIView(frame: CGRect(x: bounds.midX - width / 2,
                                      y: bounds.midY - height / 2,
                                      width: width,
                                      height: height))
-        slides[rectable.id] = slide
+        slides[rect.id] = slide
         addSubview(slide)
-        selectSlide(by: rectable.id)
-        select(by: rectable.id, to: true)
-        guard let (r, g, b) = color?.toDoubleRgb() else { return }
-        slide.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: CGFloat(rectable.alpha) / 10.0)
+        selectSlide(by: rect.id)
+        select(by: rect.id, to: true)
+        slide.backgroundColor = UIColor(skColor: rect.color, skAlpha: rect.alpha)
     }
     
     func select(by id: SKID, to isSelected: Bool) {

--- a/MyKeynote/MyKeynote/View/CanvasView.swift
+++ b/MyKeynote/MyKeynote/View/CanvasView.swift
@@ -41,17 +41,18 @@ class CanvasView: UIView {
         delegate?.canvasTapped(at: sender.location(in: self))
     }
     
-    func makeRectable(_ rectable: Rectable, color: UIColor? = nil) {
+    func makeRectable(_ rectable: Rectable, color: SKColor? = nil) {
         let (width, height) = (rectable.getWidth(), Double(rectable.height))
-        slide = UIView(frame: CGRect(x: bounds.midX - width / 2,
+        let slide = UIView(frame: CGRect(x: bounds.midX - width / 2,
                                      y: bounds.midY - height / 2,
                                      width: width,
                                      height: height))
-        slide.backgroundColor = color
-        tag = rectable.id.toInt
+        slides[rectable.id] = slide
         addSubview(slide)
         selectSlide(by: rectable.id)
         select(by: rectable.id, to: true)
+        guard let (r, g, b) = color?.toDoubleRgb() else { return }
+        slide.backgroundColor = UIColor(red: r, green: g, blue: b, alpha: CGFloat(rectable.alpha) / 10.0)
     }
     
     func select(by id: SKID, to isSelected: Bool) {
@@ -62,16 +63,20 @@ class CanvasView: UIView {
         slides.values.forEach { $0.isSelected = false }
     }
     
-    func changeColor(red: CGFloat, green: CGFloat, blue: CGFloat) {
-        slide.changeBackgroundColor(red: red, green: green, blue: blue)
+    func changeColor(id: SKID, red: CGFloat, green: CGFloat, blue: CGFloat) {
+        slides[id]?.changeBackgroundColor(red: red, green: green, blue: blue)
+    }
+    
+    func changeAlpha(id: SKID, to alpha: CGFloat) {
+        slides[id]?.changeBackgroundAlpha(to: alpha)
+    }
+    
     func selectSlide(by id: SKID) {
         isHidden = false
         subviews.forEach { $0.isHidden = true }
         slides[id]?.isHidden = false
     }
     
-    func changeAlpha(to alpha: CGFloat) {
-        slide.changeBackgroundAlpha(to: alpha)
     func deselectSlide() {
         self.isHidden = true
         subviews.forEach { $0.isHidden = true }

--- a/MyKeynote/MyKeynote/View/ColorControlView.swift
+++ b/MyKeynote/MyKeynote/View/ColorControlView.swift
@@ -78,7 +78,7 @@ class ColorControlView: UIView {
         delegate?.colorButtonTapped()
     }
     
-    func bind(_ color: SKColor?) {
+    func changeColor(to color: SKColor?) {
         guard let color else {
             colorButton.isEnabled = false
             colorButton.backgroundColor = UIColor.white

--- a/MyKeynote/MyKeynote/View/ControlStackView.swift
+++ b/MyKeynote/MyKeynote/View/ControlStackView.swift
@@ -56,17 +56,17 @@ class ControlStackView: UIView {
                                         height: frame.width * 9 / 16)
     }
     
-    func bind(alpha: Int? = nil) {
-        alphaControlView.bind(skAlpha: alpha)
+    func changeAlpha(to skAlpha: Int? = nil) {
+        alphaControlView.changeAlpha(to: skAlpha)
         
     }
-    func bind(color: SKColor? = nil) {
-        colorControlView.bind(color)
+    func changeColor(to skColor: SKColor? = nil) {
+        colorControlView.changeColor(to: skColor)
     }
     
     func deselect() {
-        alphaControlView.bind(skAlpha: nil)
-        colorControlView.bind(nil)
+        alphaControlView.changeAlpha(to: nil)
+        colorControlView.changeColor(to: nil)
     }
 }
 

--- a/MyKeynote/MyKeynote/View/ControlStackView.swift
+++ b/MyKeynote/MyKeynote/View/ControlStackView.swift
@@ -56,8 +56,11 @@ class ControlStackView: UIView {
                                         height: frame.width * 9 / 16)
     }
     
-    func bind(_ skAlpha: Int? = nil, _ color: SKColor? = nil) {
-        alphaControlView.bind(skAlpha: skAlpha)
+    func bind(alpha: Int? = nil) {
+        alphaControlView.bind(skAlpha: alpha)
+        
+    }
+    func bind(color: SKColor? = nil) {
         colorControlView.bind(color)
     }
 }

--- a/MyKeynote/MyKeynote/View/ControlStackView.swift
+++ b/MyKeynote/MyKeynote/View/ControlStackView.swift
@@ -63,6 +63,11 @@ class ControlStackView: UIView {
     func bind(color: SKColor? = nil) {
         colorControlView.bind(color)
     }
+    
+    func deselect() {
+        alphaControlView.bind(skAlpha: nil)
+        colorControlView.bind(nil)
+    }
 }
 
 extension ControlStackView: ColorControlViewDelegate {

--- a/MyKeynote/MyKeynote/View/SlideCell.swift
+++ b/MyKeynote/MyKeynote/View/SlideCell.swift
@@ -1,0 +1,8 @@
+//
+//  SlideCell.swift
+//  MyKeynote
+//
+//  Created by 조승기 on 2023/07/25.
+//
+
+import Foundation

--- a/MyKeynote/MyKeynote/View/SlideCell.swift
+++ b/MyKeynote/MyKeynote/View/SlideCell.swift
@@ -57,7 +57,7 @@ class SlideCell: UITableViewCell {
         ])
     }
     
-    func bind(index: Int) {
-        indexLabel.text = "\(index+1)"
+    func changeIndex(to index: String) {
+        indexLabel.text = index
     }
 }

--- a/MyKeynote/MyKeynote/View/SlideCell.swift
+++ b/MyKeynote/MyKeynote/View/SlideCell.swift
@@ -5,4 +5,59 @@
 //  Created by 조승기 on 2023/07/25.
 //
 
-import Foundation
+import UIKit
+
+class SlideCell: UITableViewCell {
+    // MARK: - UI properties
+    private let slideImageView = {
+        let imageView = UIImageView(image: UIImage.rectangleInsetFilled)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = .black
+        imageView.layer.borderWidth = 10
+        imageView.layer.borderColor = UIColor.lightGray.cgColor
+        imageView.layer.cornerRadius = 10
+        imageView.contentMode = .center
+        return imageView
+    }()
+    private let indexLabel = {
+        let label = UILabel()
+        label.textAlignment = .right
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 22)
+        return label
+    }()
+    // MARK: - Properties
+    static let identifier = "SlideCell"
+    
+    // MARK: - Lifecycles
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureUI()
+    }
+    
+    // MARK: - Helpers
+    private func configureUI() {
+        [slideImageView, indexLabel].forEach {
+            contentView.addSubview($0)
+        }
+        NSLayoutConstraint.activate([
+            slideImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            slideImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            slideImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            slideImageView.widthAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 4 / 3),
+            indexLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            indexLabel.trailingAnchor.constraint(equalTo: slideImageView.leadingAnchor, constant: -3),
+            indexLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 1 / 4),
+            indexLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor)
+        ])
+    }
+    
+    func bind(index: Int) {
+        indexLabel.text = "\(index+1)"
+    }
+}

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -110,7 +110,7 @@ class KeyNoteViewController: UIViewController {
     }
     
     private func bind() {
-        NotificationCenter.default.addObserver(forName: .selectedRectChanged, object: nil, queue: nil, using: { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.selectedRectChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self, let userInfo = notification.userInfo else { return }
             guard let selectedRect = userInfo["selectedRect"] as? Rectable else {
                 self.canvasView.deselect()
@@ -123,7 +123,7 @@ class KeyNoteViewController: UIViewController {
             controlStackView.bind(color: (selectedRect as? Colorful)?.color)
         })
         
-        NotificationCenter.default.addObserver(forName: .slideAlphaChanged, object: nil, queue: nil, using: { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.slideAlphaChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self,
                   let userInfo = notification.userInfo,
                   let rect = userInfo["slide"] as? Rectable else { return }
@@ -131,7 +131,7 @@ class KeyNoteViewController: UIViewController {
             canvasView.changeAlpha(id: rect.id, to: CGFloat(Double(rect.alpha) / 10))
         })
         
-        NotificationCenter.default.addObserver(forName: .rectColorChanged, object: nil, queue: nil, using: { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.rectColorChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self,
                   let userInfo = notification.userInfo,
                   let rect = userInfo["rect"] as? Rectable & Colorful else { return }
@@ -140,7 +140,7 @@ class KeyNoteViewController: UIViewController {
             canvasView.changeColor(id: rect.id, red: red, green: green, blue: blue)
         })
         
-        NotificationCenter.default.addObserver(forName: .squareMade, object: nil, queue: nil, using: { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.squareMade, object: nil, queue: nil, using: { [weak self] notification in
             guard let self,
                   let userInfo = notification.userInfo,
                   let rect = userInfo["slide"] as? Square,
@@ -155,7 +155,7 @@ class KeyNoteViewController: UIViewController {
             }
         })
         
-        NotificationCenter.default.addObserver(forName: .tableIndexChanged, object: nil, queue: nil, using: { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.tableIndexChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self, let userInfo = notification.userInfo else { return }
             guard let displayId = userInfo["id"] as? SKID else {
                 self.canvasView.deselectSlide()

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -141,7 +141,10 @@ extension KeyNoteViewController: UITableViewDelegate {
 
 extension KeyNoteViewController: CanvasViewDelegate {
     func canvasTapped(at point: CGPoint) {
-        slideManager.tapped(at: SKPoint(x: point.x, y: point.y))
+        slideManager.tapped(at: SKPoint(x: point.x,
+                                        y: point.y),
+                            center: SKPoint(x: canvasView.bounds.midX,
+                                            y: canvasView.bounds.midY))
     }
 }
 

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -13,6 +13,7 @@ class KeyNoteViewController: UIViewController {
         static let sideWidth = 200.0
     }
     //MARK: - UI Property
+    private let tableView = UITableView()
     private let canvasView = CanvasView()
     private let controlStackView = ControlStackView()
     private let backgroundView = {
@@ -39,7 +40,7 @@ class KeyNoteViewController: UIViewController {
     
     override func loadView() {
         super.loadView()
-        [backgroundView, canvasView, controlStackView].forEach {
+        [backgroundView, canvasView, controlStackView, tableView].forEach {
             view.addSubview($0)
         }
         view.backgroundColor = .darkGray
@@ -71,11 +72,17 @@ class KeyNoteViewController: UIViewController {
                                         y: safeRect.minY,
                                         width: Constant.sideWidth,
                                         height: view.frame.height - safeRect.minY)
+        
+        tableView.frame = CGRect(x: 0,
+                                 y: safeRect.minY,
+                                 width: Constant.sideWidth,
+                                 height: view.frame.height - safeRect.minY)
     }
     
     private func configureEvent() {
         canvasView.delegate = self
         controlStackView.delegate = self
+        tableView.delegate = self
         bind()
     }
     
@@ -102,6 +109,10 @@ class KeyNoteViewController: UIViewController {
         guard let tag else { return nil }
         return canvasView.viewWithTag(tag)
     }
+}
+
+extension KeyNoteViewController: UITableViewDelegate {
+    
 }
 
 extension KeyNoteViewController: CanvasViewDelegate {

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -20,13 +20,6 @@ class KeyNoteViewController: UIViewController {
         view.backgroundColor = .systemGray2
         return view
     }()
-    private let makeRectButton = {
-        let button = UIButton()
-        button.backgroundColor = .red
-        button.setTitle("+", for: .normal)
-        button.setTitleColor(UIColor.green, for: .normal)
-        return button
-    }()
     //MARK: - Property
     var slideManager: SlideManagerProtocol
     private var selectedRectTag: Int?
@@ -46,7 +39,7 @@ class KeyNoteViewController: UIViewController {
     
     override func loadView() {
         super.loadView()
-        [backgroundView, canvasView, controlStackView, makeRectButton].forEach {
+        [backgroundView, canvasView, controlStackView].forEach {
             view.addSubview($0)
         }
         view.backgroundColor = .darkGray
@@ -78,11 +71,6 @@ class KeyNoteViewController: UIViewController {
                                         y: safeRect.minY,
                                         width: Constant.sideWidth,
                                         height: view.frame.height - safeRect.minY)
-        
-        makeRectButton.frame = CGRect(x: 0,
-                                      y: safeRect.midY - 50,
-                                      width: 100,
-                                      height: 100)
     }
     
     private func configureEvent() {

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -166,8 +166,10 @@ extension KeyNoteViewController: UIColorPickerViewControllerDelegate {
         var (red, green, blue): (CGFloat, CGFloat, CGFloat) = (0, 0, 0)
         viewController.selectedColor.getRed(&red, green: &green, blue: &blue, alpha: nil)
         
-        slideManager.changeColor(to: SKColor(red: UInt8(red * 255),
-                                             green: UInt8(green * 255),
-                                             blue: UInt8(blue * 255)))
+        let skColor = SKColor(red: UInt8(red * 255),
+                              green: UInt8(green * 255),
+                              blue: UInt8(blue * 255))
+        slideManager.changeColor(to: skColor)
+        controlStackView.bind(color: skColor)
     }
 }

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -95,12 +95,19 @@ class KeyNoteViewController: UIViewController {
     }
     
     private func bind() {
-        slideManager.changed = { [weak self] rect in
-            guard let self, let rect else { return }
-            let view = findSubview(tag: IDService.toInt(rect.id))
-            view?.changeBackgroundColor(rect.alpha, (rect as? Colorful)?.color)
-            controlStackView.bind(rect.alpha, (rect as? Colorful)?.color)
-        }
+        NotificationCenter.default.addObserver(forName: .selectedRectChanged, object: nil, queue: nil, using: { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let selectedRect = userInfo["selectedRect"] as? Rectable else {
+                self?.canvasView.changeSelection(to: false)
+                self?.controlStackView.bind(alpha: nil)
+                self?.controlStackView.bind(color: nil)
+                return
+            }
+            canvasView.changeSelection(to: true)
+            controlStackView.bind(alpha: selectedRect.alpha)
+            controlStackView.bind(color: (selectedRect as? Colorful)?.color)
+        })
         
         slideManager.selectedRectDidChanged = { [weak self] rect in
             guard let self else { return }

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -18,6 +18,16 @@ class KeyNoteViewController: UIViewController {
     private let tableView = UITableView()
     private let canvasView = CanvasView()
     private let controlStackView = ControlStackView()
+    private let makeSlideButton = {
+        let button = UIButton()
+        button.setTitle("( + )", for: .normal)
+        button.setTitleColor(UIColor.blue, for: .normal)
+        button.backgroundColor = .cyan
+        button.tintColor = .blue
+        button.layer.cornerRadius = 10
+        button.addTarget(self, action: #selector(makeSlideButtonTapped(sender:)), for: .touchUpInside)
+        return button
+    }()
     private let backgroundView = {
         let view = UIView()
         view.backgroundColor = .systemGray2
@@ -25,7 +35,6 @@ class KeyNoteViewController: UIViewController {
     }()
     //MARK: - Property
     var slideManager: SlideManagerProtocol
-    private var selectedRectTag: Int?
     
     //MARK: - LifeCycle
     init(slideManager: SlideManagerProtocol) {
@@ -42,11 +51,10 @@ class KeyNoteViewController: UIViewController {
     
     override func loadView() {
         super.loadView()
-        [backgroundView, canvasView, controlStackView, tableView].forEach {
+        [backgroundView, controlStackView, canvasView, tableView, makeSlideButton].forEach {
             view.addSubview($0)
         }
         view.backgroundColor = .darkGray
-        configureEvent()
     }
     
     override func viewSafeAreaInsetsDidChange() {
@@ -78,7 +86,7 @@ class KeyNoteViewController: UIViewController {
                                       width: safeRect.width,
                                       height: safeRect.minY + safeRect.height)
         
-        controlStackView.frame = CGRect(x: canvasView.frame.maxX,
+        controlStackView.frame = CGRect(x: safeRect.maxX - Constant.sideWidth,
                                         y: safeRect.minY,
                                         width: Constant.sideWidth,
                                         height: view.frame.height - safeRect.minY)
@@ -86,13 +94,19 @@ class KeyNoteViewController: UIViewController {
         tableView.frame = CGRect(x: 0,
                                  y: safeRect.minY,
                                  width: Constant.sideWidth,
-                                 height: view.frame.height - safeRect.minY)
+                                 height: view.frame.height - safeRect.minY - Constant.makeRectButtonHeight)
+        
+        makeSlideButton.frame = CGRect(x: 0,
+                                       y: tableView.frame.maxY,
+                                       width: Constant.sideWidth,
+                                       height: Constant.makeRectButtonHeight)
     }
     
     private func configureEvent() {
         canvasView.delegate = self
         controlStackView.delegate = self
         tableView.delegate = self
+        tableView.register(SlideCell.self, forCellReuseIdentifier: SlideCell.identifier)
         bind()
     }
     
@@ -131,9 +145,8 @@ class KeyNoteViewController: UIViewController {
         })
     }
     
-    private func findSlide(with tag: Int?) -> CanvasView? {
-        guard let tag else { return nil }
-        return view.subviews.first { $0.tag == tag } as? CanvasView
+    @objc func makeSlideButtonTapped(sender: UIButton!) {
+        slideManager.makeRect(by: Square.self, photo: nil)
     }
 }
 

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -110,23 +110,23 @@ class KeyNoteViewController: UIViewController {
     }
     
     private func bind() {
-        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.selectedRectChanged, object: nil, queue: nil, using: { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: SlideManager.Notifications.selectedSlideChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self, let userInfo = notification.userInfo else { return }
-            guard let selectedRect = userInfo["selectedRect"] as? Rectable else {
+            guard let selectedSlide = userInfo[SlideManager.UserInfoKeys.selectedSlide] as? Rectable else {
                 self.canvasView.deselect()
                 self.controlStackView.deselect()
                 return
             }
         
-            canvasView.select(by: selectedRect.id, to: true)
-            controlStackView.changeAlpha(to: selectedRect.alpha)
-            controlStackView.changeColor(to: (selectedRect as? Colorful)?.color)
+            canvasView.select(by: selectedSlide.id, to: true)
+            controlStackView.changeAlpha(to: selectedSlide.alpha)
+            controlStackView.changeColor(to: (selectedSlide as? Colorful)?.color)
         })
         
         NotificationCenter.default.addObserver(forName: SlideManager.Notifications.slideAlphaChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self,
                   let userInfo = notification.userInfo,
-                  let rect = userInfo["slide"] as? Rectable else { return }
+                  let rect = userInfo[SlideManager.UserInfoKeys.slide] as? Rectable else { return }
             
             canvasView.changeAlpha(id: rect.id, to: CGFloat(Double(rect.alpha) / 10))
         })
@@ -134,7 +134,7 @@ class KeyNoteViewController: UIViewController {
         NotificationCenter.default.addObserver(forName: SlideManager.Notifications.rectColorChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self,
                   let userInfo = notification.userInfo,
-                  let rect = userInfo["rect"] as? Rectable & Colorful else { return }
+                  let rect = userInfo[SlideManager.UserInfoKeys.rect] as? Rectable & Colorful else { return }
             
             let (red, green, blue) = rect.color.toDoubleRgb()
             canvasView.changeColor(id: rect.id, red: red, green: green, blue: blue)
@@ -143,8 +143,8 @@ class KeyNoteViewController: UIViewController {
         NotificationCenter.default.addObserver(forName: SlideManager.Notifications.squareMade, object: nil, queue: nil, using: { [weak self] notification in
             guard let self,
                   let userInfo = notification.userInfo,
-                  let rect = userInfo["slide"] as? Square,
-                  let index = userInfo["index"] as? Int else { return }
+                  let rect = userInfo[SlideManager.UserInfoKeys.slide] as? Square,
+                  let index = userInfo[SlideManager.UserInfoKeys.index] as? Int else { return }
             
             self.canvasView.makeSlide(rect)
             self.controlStackView.changeAlpha(to: rect.alpha)
@@ -157,7 +157,7 @@ class KeyNoteViewController: UIViewController {
         
         NotificationCenter.default.addObserver(forName: SlideManager.Notifications.tableIndexChanged, object: nil, queue: nil, using: { [weak self] notification in
             guard let self, let userInfo = notification.userInfo else { return }
-            guard let displayId = userInfo["id"] as? SKID else {
+            guard let displayId = userInfo[SlideManager.UserInfoKeys.id] as? SKID else {
                 self.canvasView.deselectSlide()
                 return
             }

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -13,17 +13,13 @@ class KeyNoteViewController: UIViewController {
         static let sideWidth = 200.0
     }
     //MARK: - UI Property
-    private let canvasView = {
-        let view = UIView()
-        view.backgroundColor = .white
-        return view
-    }()
+    private let canvasView = CanvasView()
+    private let controlStackView = ControlStackView()
     private let backgroundView = {
         let view = UIView()
         view.backgroundColor = .systemGray2
         return view
     }()
-    private let controlStackView = ControlStackView()
     private let makeRectButton = {
         let button = UIButton()
         button.backgroundColor = .red
@@ -90,11 +86,8 @@ class KeyNoteViewController: UIViewController {
     }
     
     private func configureEvent() {
+        canvasView.delegate = self
         controlStackView.delegate = self
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(canvasTapped(sender:)))
-        view.addGestureRecognizer(tapGestureRecognizer)
-        
-        makeRectButton.addTarget(self, action: #selector(newSquareButtonTapped(_:)), for: .touchUpInside)
         bind()
     }
     
@@ -116,27 +109,16 @@ class KeyNoteViewController: UIViewController {
             controlStackView.bind(rect?.alpha, (rect as? Colorful)?.color)
         }
     }
-    @objc func newSquareButtonTapped(_ sender: UIButton!) {
-        let square = slideManager.makeRect(by: Square.self, photo: nil)
-        let newView = UIView(frame: CGRect(x: square.point.x,
-                                           y: square.point.y,
-                                           width: square.getWidth(),
-                                           height: Double(square.height)))
-        newView.backgroundColor = UIColor(skColor: square.color, skAlpha: square.alpha)
-        newView.tag = IDService.toInt(square.id) ?? 0
-        canvasView.addSubview(newView)
-    }
-    
-    @objc func canvasTapped(sender: UITapGestureRecognizer) {
-        let point = sender.location(in: canvasView)
-        guard canvasView.bounds.contains(point) else { return }
-        slideManager.tapped(at: SKPoint(x: point.x,
-                                        y: point.y))
-    }
     
     private func findSubview(tag: Int?) -> UIView? {
         guard let tag else { return nil }
         return canvasView.viewWithTag(tag)
+    }
+}
+
+extension KeyNoteViewController: CanvasViewDelegate {
+    func canvasTapped(at point: CGPoint) {
+        slideManager.tapped(at: SKPoint(x: point.x, y: point.y))
     }
 }
 

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -51,6 +51,14 @@ class KeyNoteViewController: UIViewController {
         super.viewSafeAreaInsetsDidChange()
         configureFrame()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        let square = slideManager.makeRect(by: Square.self, photo: nil)
+        canvasView.makeRectable(square, color: UIColor(skColor: square.color, skAlpha: square.alpha))
+
+    }
+    
     //MARK: - Helper
     private func configureFrame() {
         let safeRect = view.safeAreaLayoutGuide.layoutFrame

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -109,15 +109,24 @@ class KeyNoteViewController: UIViewController {
             controlStackView.bind(color: (selectedRect as? Colorful)?.color)
         })
         
-        slideManager.selectedRectDidChanged = { [weak self] rect in
-            guard let self else { return }
-            let oldView = findSubview(tag: selectedRectTag)
-            oldView?.isSelected = false
-            let view = findSubview(tag: IDService.toInt(rect?.id))
-            view?.isSelected = true
-            selectedRectTag = IDService.toInt(rect?.id)
-            controlStackView.bind(rect?.alpha, (rect as? Colorful)?.color)
-        }
+        NotificationCenter.default.addObserver(forName: .slideAlphaChanged, object: nil, queue: nil, using: { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let rect = userInfo["slide"] as? Rectable else { return }
+            
+            let slide = findSlide(with: rect.id.toInt)
+            slide?.changeAlpha(to: CGFloat(Double(rect.alpha) / 10))
+        })
+        
+        NotificationCenter.default.addObserver(forName: .rectColorChanged, object: nil, queue: nil, using: { [weak self] notification in
+            guard let self,
+                  let userInfo = notification.userInfo,
+                  let rect = userInfo["rect"] as? Rectable & Colorful else { return }
+            
+            let slide = findSlide(with: rect.id.toInt)
+            let (red, green, blue) = rect.color.toDoubleRgb()
+            slide?.changeColor(red: red, green: green, blue: blue)
+        })
     }
     
     private func findSubview(tag: Int?) -> UIView? {

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -166,7 +166,7 @@ class KeyNoteViewController: UIViewController {
     }
     
     @objc func makeSlideButtonTapped(sender: UIButton!) {
-        slideManager.makeRect(by: Square.self, photo: nil)
+        slideManager.makeSquare()
     }
 }
 

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -119,8 +119,8 @@ class KeyNoteViewController: UIViewController {
             }
         
             canvasView.select(by: selectedRect.id, to: true)
-            controlStackView.bind(alpha: selectedRect.alpha)
-            controlStackView.bind(color: (selectedRect as? Colorful)?.color)
+            controlStackView.changeAlpha(to: selectedRect.alpha)
+            controlStackView.changeColor(to: (selectedRect as? Colorful)?.color)
         })
         
         NotificationCenter.default.addObserver(forName: SlideManager.Notifications.slideAlphaChanged, object: nil, queue: nil, using: { [weak self] notification in
@@ -146,9 +146,9 @@ class KeyNoteViewController: UIViewController {
                   let rect = userInfo["slide"] as? Square,
                   let index = userInfo["index"] as? Int else { return }
             
-            self.canvasView.makeRectable(rect, color: rect.color)
-            self.controlStackView.bind(alpha: rect.alpha)
-            self.controlStackView.bind(color: rect.color)
+            self.canvasView.makeSlide(rect)
+            self.controlStackView.changeAlpha(to: rect.alpha)
+            self.controlStackView.changeColor(to: rect.color)
             DispatchQueue.main.async {
                 self.tableView.insertRows(at: [IndexPath(row: self.slideManager.count-1, section: 0)], with: .automatic)
                 self.tableView.selectRow(at: IndexPath(row: index, section: 0), animated: true, scrollPosition: .middle)
@@ -190,7 +190,7 @@ extension KeyNoteViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SlideCell.identifier,
                                                        for: indexPath) as? SlideCell else { return UITableViewCell() }
-        cell.bind(index: indexPath.row)
+        cell.changeIndex(to: "\(indexPath.row+1)")
         return cell
     }
     
@@ -230,6 +230,6 @@ extension KeyNoteViewController: UIColorPickerViewControllerDelegate {
                               green: UInt8(green * 255),
                               blue: UInt8(blue * 255))
         slideManager.changeColor(to: skColor)
-        controlStackView.bind(color: skColor)
+        controlStackView.changeColor(to: skColor)
     }
 }

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -10,7 +10,9 @@ import os
 
 class KeyNoteViewController: UIViewController {
     enum Constant {
-        static let sideWidth = 200.0
+        static let sideWidth = 175.0
+        static let cellHeight = 95.0
+        static let makeRectButtonHeight = 50.0
     }
     //MARK: - UI Property
     private let tableView = UITableView()

--- a/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
+++ b/MyKeynote/MyKeynote/ViewController/KeyNoteViewController.swift
@@ -129,9 +129,9 @@ class KeyNoteViewController: UIViewController {
         })
     }
     
-    private func findSubview(tag: Int?) -> UIView? {
+    private func findSlide(with tag: Int?) -> CanvasView? {
         guard let tag else { return nil }
-        return canvasView.viewWithTag(tag)
+        return view.subviews.first { $0.tag == tag } as? CanvasView
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@
 - [x] 투명도, 배경색 입출력 흐름 구현 - 20분 - (7/20 11:07)
 
 ### 7/20 목
-- [ ] 옵저버 패턴 공부 및 정리 - 30분
-- [ ] M - VC 간의 관계를 Notification Center로 변경 - 30분
-- [ ] TableViewDataSource 공부및 정리 - 30분
-- [ ] 🖌️ Custom TableViewCell - 30분 
-- [ ] 🖌️ TableView UI - 30분
-- [ ] TableView Delegate - 1시간 
+- [x] 옵저버 패턴 공부 및 정리 - 30분
+- [x] M - VC 간의 관계를 Notification Center로 변경 - 30분 (7/25 17:24)
+- [x] TableViewDataSource 공부및 정리 - 30분
+- [x] 🖌️ Custom TableViewCell - 30분 
+- [x] 🖌️ TableView UI - 30분
+- [x] TableView Delegate - 1시간 (7/26 20:30)
 
 ### 7/20 금
 - [ ] 리팩토링과 밀렸다면 과제 - 2시간
@@ -55,4 +55,20 @@
 ![](https://i.ibb.co/5nGwDJK/Simulator-Screen-Recording-i-Pad-Pro-11-inch-4th-generation-2023-07-24-at-10-20-31.gif)
 - 선택 후 배경색, 투명도 조절 가능
 - 빈 영역 터치 시 선택 해제
+</details>
+
+<details> 
+<summary>W4</summary>
+
+(7/25 17:25)
+![](https://i.ibb.co/5nGwDJK/Simulator-Screen-Recording-i-Pad-Pro-11-inch-4th-generation-2023-07-24-at-10-20-31.gif)
+- 기존과 같지만 옵저버로 변경 . . .
+----
+(7/26 20:30)
+![](https://i.ibb.co/5kcy60S/Simulator-Screen-Recording-i-Pad-Pro-11-inch-4th-generation-2023-07-26-at-20-55-22.gif)
+
+- 테이블뷰
+- UITableViewDelegate 이용, 선택과 해제 가능
+- Input흐름과 Output흐름 분리
+
 </details>


### PR DESCRIPTION
## 작업 내용
![](https://i.ibb.co/5kcy60S/Simulator-Screen-Recording-i-Pad-Pro-11-inch-4th-generation-2023-07-26-at-20-55-22.gif)

## 고민과 해결 과정

- 팩토리 다형성 제거
    - `func makeSquare() -> Square`
    - color혹은 이미지 같이 특수화 init이 필요한 상황에서 
    - 다형성을 위해 파라미터를 초기화하지 않는 것 보단, 팩토리의 생성 메소드를 여러 개 만드는 것이 낫다고 판단했습니다.

- 옵셔널 타입으로 분기 처리
	```swift
	guard let displayId = userInfo["id"] as? SKID else {
            self.canvasView.deselectSlide()
            return
        }
	canvasView.selectSlide(by: displayId)
	```
	- 위와 guard else 문 처럼 displayId가 없으면, 안 보여준다는 의미로 처리했는데
	- 결국 분기처리니까 두가지 일을 수행하는 코드를 짜버렸습니다.
    - 함수가 많아지더라도 분리해야겠습니다.